### PR TITLE
fix: Rename master to main

### DIFF
--- a/.github/workflows/deploy-hugo-site.yml
+++ b/.github/workflows/deploy-hugo-site.yml
@@ -5,7 +5,7 @@ on:
   # Run on pushes to the default branch
   push:
     branches:
-      - master
+      - main
   # Add an option to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Renamed the default branch from `master` to `main` directly on github.com.

The github workflows also mention the default branch name, hence require updates.