### PR TITLE
feat: Add google analytics measurement ID

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -15,7 +15,7 @@ summaryLength = 30
 buildDrafts = false
 buildFuture = false
 
-googleAnalytics = ""
+googleAnalytics = "G-K9NTMXPGN3"
 
 [imaging]
   anchor = 'Center'


### PR DESCRIPTION
This PR adds Google Analytics measurement ID.

The change is very straightforward, the review is not required.