### PR TITLE
feat: Set fork of theme repo as submodule and clone it shallow by def…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,5 @@
 [submodule "themes/blowfish"]
 	path = themes/blowfish
-	url = https://github.com/nunocoracao/blowfish.git
-	branch = main
+	url = https://github.com/espressif/blowfish.git
+	branch = espressif-developer-portal
+	shallow = true


### PR DESCRIPTION
Currently, this repo has the original theme project [nunocoracao / blowfish](https://github.com/nunocoracao/blowfish) set as a submodule. This PR offers to set a [fork](https://github.com/f-hollow/blowfish) (**!move this fork under `espressif/blowfish`!**) of the original theme project as a submodule due to the following benefits:

- A fork allows us to have a branch ([espressif-developer-portal](https://github.com/f-hollow/blowfish/tree/espressif-developer-portal)) where we can make our own updates to the theme (I already deleted multimedia files there that we are definitely not going to use) and where we can pull changes from `upstream/main` in a controlled way.
- Having our own branch also allows us to set it as the default submodule branch which we can clone in a shallow manner if we add `shallow = true` to `.gitmodules`.

As a result, running the basic command `git clone --recursive https://github.com/espressif/developer-portal.git` results in a clone of only 104 MB done in under one minute (as opposed to the current 500 MB in 2-3 minutes).