### PR TITLE
fix(author): Fix link in article to author page

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -45,7 +45,7 @@
 
     {{ range $taxonomyname, $taxonomy := $taxonomies }}
     {{ if (eq $taxonomyname $author) }}
-    {{ $taxonomyLink = delimit (slice $baseURL "/authors/" $author) "" }}
+    {{ $taxonomyLink = delimit (slice $baseURL "authors/" $author) "" }}
     {{ end }}
     {{ end }}
 


### PR DESCRIPTION
Fixes link generation for the author badge in articles. Currently the link generated has an extra `/` that results in a 404 error.

For example [here](https://developer.espressif.com/pages/contribution-guide/content-writing-workflow/) the author link generated is `https://developer.espressif.com//authors/kirill-chalov`.


