### PR TITLE
CI/move link checking to pr checks

### DIFF
--- a/.github/workflows/deploy-hugo-site.yml
+++ b/.github/workflows/deploy-hugo-site.yml
@@ -26,25 +26,6 @@ defaults:
     shell: bash
 
 jobs:
-  check-links:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Link Checker
-        id: lychee
-        uses: lycheeverse/lychee-action@v1
-        with:
-          args: |
-            --no-progress
-            --include-fragments
-            --exclude-path ./themes/
-            --exclude-path ./layouts/
-            --exclude-path ./content/blog/nuttx-getting-started/
-            .
-          # Fail action on broken links
-          fail: true
-
   build-and-deploy:
     needs: check-links
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-check-links.yml
+++ b/.github/workflows/pr-check-links.yml
@@ -1,0 +1,25 @@
+name: Check links
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: |
+            --no-progress
+            --include-fragments
+            --exclude-path ./themes/
+            --exclude-path ./layouts/
+            --exclude-path ./content/blog/nuttx-getting-started/
+            .
+          # Fail action on broken links
+          fail: true

--- a/.github/workflows/pr-check-links.yml
+++ b/.github/workflows/pr-check-links.yml
@@ -19,7 +19,6 @@ jobs:
             --include-fragments
             --exclude-path ./themes/
             --exclude-path ./layouts/
-            --exclude-path ./content/blog/nuttx-getting-started/
             .
           # Fail action on broken links
           fail: true

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,4 @@
+# content/blog/books-simplified-embedded-rust/index.md
+http://ser-book.com/espnostd
+http://ser-book.com/espstd
+https://www.theembeddedrustacean.com/subscribe


### PR DESCRIPTION
This PR moves link checking from the merge checks to PR checks. If the contributed changes have invalid links, the workflow being contributed will block the PR merge. The PR will be unblocked only after all the invalid links are fixed or added to `.lycheeignore` for a good reason.

In addition to this PR, we need to create a ruleset for our main branch.

This PR also adds some links to the `.lycheeignore` file. These links require CAPTCHA checks, which is being reported by lychee as if the links are invalid. This is a known problem and ignoring such links is a standard solution.

After this PR, we can also add workflows for

- Preventing PNG and JPEG images from being merged in favor of `.webp`
- Checks for formatting
- Linters and spellcheckers