### PR TITLE
ci: add workflow that rejects merging jpeg and png images

### DIFF
--- a/.github/workflows/cron-check-links.yml
+++ b/.github/workflows/cron-check-links.yml
@@ -1,0 +1,32 @@
+name: Cron job to check links
+
+# Schedule to run the link checker every Monday at 2:00 AM UTC
+on:
+  schedule:
+    - cron: '0 2 * * 1'
+  workflow_dispatch: # Allow manual runs
+
+jobs:
+  cron-check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: |
+            --no-progress
+            --include-fragments
+            --exclude-path ./themes/
+            --exclude-path ./layouts/
+            .
+
+      - name: Suggestions
+        if: failure()
+        run: |
+          echo -e "\nPlease review the links reported in Link Checker step above."
+          echo -e "If a link is valid but fails due to a CAPTCHA challenge, IP blocking, login requirements, etc.,
+          consider adding such links to .lycheeignore file to bypass future checks.\n"
+          exit 1

--- a/.github/workflows/pr-check-file-names.yml
+++ b/.github/workflows/pr-check-file-names.yml
@@ -1,0 +1,29 @@
+name: Check filenames for spaces
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-filenames-spaces:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history to ensure we can access all branches
+
+      - name: Check filenames for spaces
+        id: list-files
+        run: |
+          # Get the list of added files from the pull request
+          FILENAMES_SPACES=$(git diff --name-only origin/main...HEAD | ( grep "\s" || true ) )
+
+          if [ -n "$FILENAMES_SPACES" ]; then
+            echo "Rejecting merge. PR has the following files with spaces in their names:"
+            echo "$FILENAMES_SPACES"
+            echo "Please replace the spaces, for example, with a dash."
+            exit 1
+
+          else
+            echo "All added files have no spaces."
+          fi

--- a/.github/workflows/pr-check-links.yml
+++ b/.github/workflows/pr-check-links.yml
@@ -22,3 +22,11 @@ jobs:
             .
           # Fail action on broken links
           fail: true
+
+      - name: Suggestions
+        if: failure()
+        run: |
+          echo -e "\nPlease review the links reported in Link Checker step above."
+          echo -e "If a link is valid but fails due to a CAPTCHA challenge, IP blocking, login requirements, etc.,
+          consider adding such links to .lycheeignore file to bypass future checks.\n"
+          exit 1

--- a/.github/workflows/pr-reject-png-jpg.yml
+++ b/.github/workflows/pr-reject-png-jpg.yml
@@ -1,0 +1,29 @@
+name: Reject JPEG/PNG files
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  reject-jpg-png:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history to ensure we can access all branches
+
+      - name: Check for JPEG and PNG files
+        run: |
+          # Check for .jpeg, .jpg, .JPG, .JPEG, .png, .PNG files
+          IMAGE_FILES=$(git diff --name-only origin/main...HEAD | (grep -iE '\.(jpe?g|png)$' || true) )
+
+          if [ -n "$IMAGE_FILES" ]; then
+            echo "Rejecting merge. PR contains the following JPEG or PNG files:"
+            echo "$IMAGE_FILES"
+            echo "Please convert these files to WebP format."
+            exit 1
+
+          else
+            echo "No JPEG or PNG files found."
+          fi


### PR DESCRIPTION
This PR adds a workflow to check if the changes in a PR have PNG and JPEG images. If yes, it blocks the PR for merging and asks to convert the images to WebP.

It also includes other smaller workflows:

- Adds a workflow that rejects filenames with spaces and asks, for example, to replace them with dashes.
- Adds instructions to the existing link checking workflow, because without them, it is not clear now what to do with links that failed automatic checking but are still valid (for example due to CAPTCHA or login requests).
- Adds a cron job to check links in all devportal content on the main branch every Monday.