### PR TITLE
ci: Change workflow pr-check-links to review only the diffs

### DIFF
--- a/.github/workflows/cron-check-links.yml
+++ b/.github/workflows/cron-check-links.yml
@@ -22,6 +22,8 @@ jobs:
             --exclude-path ./themes/
             --exclude-path ./layouts/
             .
+          # Fail action on broken links
+          fail: true
 
       - name: Suggestions
         if: failure()

--- a/.github/workflows/pr-check-links.yml
+++ b/.github/workflows/pr-check-links.yml
@@ -1,4 +1,4 @@
-name: Check links
+name: Check links in diffs
 
 on:
   pull_request:
@@ -8,10 +8,45 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      - name: Link Checker
-        id: lychee
+      - name: Check out main branch
+        run: git checkout main
+
+      - name: Dump all links from main
+        id: dump_links_from_main
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: |
+            --dump
+            --include-fragments
+            --exclude-path ./themes/
+            --exclude-path ./layouts/
+            .
+          output: ./links-main.txt
+
+      - name: Print links-main.txt in main
+        run: cat links-main.txt
+
+      - name: Stash untracked files
+        run: git stash push --include-untracked
+
+      - name: Check out feature branch
+        run: git checkout ${{ github.head_ref }}
+
+      - name: Apply stashed changes
+        # Apply stashed changes, ignore errors if stash is empty
+        run: git stash pop || true
+
+      - name: Append links-main.txt to .lycheeignore
+        run: cat links-main.txt >> .lycheeignore
+
+      - name: Check links
         uses: lycheeverse/lychee-action@v1
         with:
           args: |
@@ -26,7 +61,7 @@ jobs:
       - name: Suggestions
         if: failure()
         run: |
-          echo -e "\nPlease review the links reported in Link Checker step above."
+          echo -e "\nPlease review the links reported in the Check links step above."
           echo -e "If a link is valid but fails due to a CAPTCHA challenge, IP blocking, login requirements, etc.,
           consider adding such links to .lycheeignore file to bypass future checks.\n"
           exit 1


### PR DESCRIPTION
This PR limits link checking by `pr-check-links` to the PR diffs only.

Created an issue in the [lychee-action](https://github.com/lycheeverse/lychee-action/issues/238) repo to collect further feedback.