### PR TITLE
ci[pr-check-links]: dump links from baseline commit for pr link checking

### DIFF
--- a/.github/workflows/pr-check-links.yml
+++ b/.github/workflows/pr-check-links.yml
@@ -11,22 +11,30 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          fetch-depth: 0
+
+      - name: Set environment variables
+        id: set-env
+        run: |
+          # Extract the base commit ID where the feature branch diverged from main
+          base_commit=$(git merge-base origin/main ${{ github.event.pull_request.head.ref }})
+          echo "base_commit=$base_commit" >> $GITHUB_ENV
+
+          # Extract the head commit ID on the feature branch
+          head_commit=${{ github.event.pull_request.head.sha }}
+          echo "head_commit=$head_commit" >> $GITHUB_ENV
 
       - name: Create baseline branch by reverting feature branch changes
         run: |
           # Create a copy of the feature branch
-          git checkout -b baseline-copy
-
-          # Find the base commit where the feature branch diverged from main
-          base_commit=$(git merge-base origin/main baseline-copy)
+          git checkout -b feature-baseline
 
           # Reset the new branch to the base commit
-          git reset --hard $base_commit
+          git reset --hard ${{ env.base_commit }}
 
-      - name: Dump all links from baseline-copy
+      - name: Dump all links from feature-baseline
         uses: lycheeverse/lychee-action@v2.0.2
         with:
           args: |
@@ -44,6 +52,34 @@ jobs:
         run: cat links-baseline.txt >> .lycheeignore
 
       - name: Print .lycheeignore
+        run: cat .lycheeignore
+
+      - name: Dump names of files altered in PR and append hash sign to find links with anchors
+        run: |
+          git diff --name-only --diff-filter=DM ${{ env.base_commit }} ${{ env.head_commit }} > altered-files.txt
+          sed -i 's|$|#|' altered-files.txt
+          git diff --name-status --diff-filter=R ${{ env.base_commit }} ${{ env.head_commit }} | awk '{print $2}' > renamed-files.txt
+          sed -i 's|$|#|' renamed-files.txt
+
+      - name: Print altered-files.txt
+        run: cat altered-files.txt
+
+      - name: Print renamed-files.txt
+        run: cat renamed-files.txt
+
+      - name: In .lycheeignore, remove links with anchors referring to altered files
+        run: |
+          while IFS= read -r line; do
+            sed -i "\|$line|d" .lycheeignore
+          done < altered-files.txt
+
+      - name: In .lycheeignore, remove links with anchors referring to renamed files
+        run: |
+          while IFS= read -r line; do
+            sed -i "\|$line|d" .lycheeignore
+          done < renamed-files.txt
+
+      - name: Print .lycheeignore with unaffected links
         run: cat .lycheeignore
 
       - name: Check links

--- a/.github/workflows/pr-check-links.yml
+++ b/.github/workflows/pr-check-links.yml
@@ -15,15 +15,10 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
-      - name: Fetch all branches
-        run: git fetch --all
-
       - name: Create baseline branch by reverting feature branch changes
         run: |
           # Create a copy of the feature branch
           git checkout -b baseline-copy
-
-          # git checkout ${{ github.event.pull_request.head.sha }}
 
           # Find the base commit where the feature branch diverged from main
           base_commit=$(git merge-base origin/main baseline-copy)
@@ -40,25 +35,15 @@ jobs:
             --exclude-path ./themes/
             --exclude-path ./layouts/
             .
-          output: ./links-baseline.txt
-
-      - name: Print links-baseline.txt
-        run: cat links-baseline.txt
-
-      - name: Stash untracked files
-        run: git stash push --include-untracked
+          output: links-baseline.txt
 
       - name: Check out feature branch
         run: git checkout ${{ github.head_ref }}
 
-      - name: Apply stashed changes
-        # Apply stashed changes, ignore errors if stash is empty
-        run: git stash pop || true
-
       - name: Append links-baseline.txt to .lycheeignore
         run: cat links-baseline.txt >> .lycheeignore
 
-      - name: Check .lycheeignore content
+      - name: Print .lycheeignore
         run: cat .lycheeignore
 
       - name: Check links
@@ -79,3 +64,9 @@ jobs:
           echo -e "If a link is valid but fails due to a CAPTCHA challenge, IP blocking, login requirements, etc.,"
           echo -e "consider adding such links to the .lycheeignore file to bypass future checks.\n"
           exit 1
+
+      - name: Clean up all changes
+        if: always()
+        run: |
+          git reset --hard HEAD
+          git clean -df

--- a/.github/workflows/pr-check-links.yml
+++ b/.github/workflows/pr-check-links.yml
@@ -11,15 +11,27 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
 
-      - name: Check out main branch
-        run: git checkout main
+      - name: Fetch all branches
+        run: git fetch --all
 
-      - name: Dump all links from main
-        id: dump_links_from_main
+      - name: Create baseline branch by reverting feature branch changes
+        run: |
+          # Create a copy of the feature branch
+          git checkout -b baseline-copy
+
+          # git checkout ${{ github.event.pull_request.head.sha }}
+
+          # Find the base commit where the feature branch diverged from main
+          base_commit=$(git merge-base origin/main baseline-copy)
+
+          # Reset the new branch to the base commit
+          git reset --hard $base_commit
+
+      - name: Dump all links from baseline-copy
         uses: lycheeverse/lychee-action@v2.0.2
         with:
           args: |
@@ -28,10 +40,10 @@ jobs:
             --exclude-path ./themes/
             --exclude-path ./layouts/
             .
-          output: ./links-main.txt
+          output: ./links-baseline.txt
 
-      - name: Print links-main.txt in main
-        run: cat links-main.txt
+      - name: Print links-baseline.txt
+        run: cat links-baseline.txt
 
       - name: Stash untracked files
         run: git stash push --include-untracked
@@ -43,8 +55,8 @@ jobs:
         # Apply stashed changes, ignore errors if stash is empty
         run: git stash pop || true
 
-      - name: Append links-main.txt to .lycheeignore
-        run: cat links-main.txt >> .lycheeignore
+      - name: Append links-baseline.txt to .lycheeignore
+        run: cat links-baseline.txt >> .lycheeignore
 
       - name: Check .lycheeignore content
         run: cat .lycheeignore

--- a/.github/workflows/pr-reject-png-jpg.yml
+++ b/.github/workflows/pr-reject-png-jpg.yml
@@ -21,7 +21,8 @@ jobs:
           if [ -n "$IMAGE_FILES" ]; then
             echo "Rejecting merge. PR contains the following JPEG or PNG files:"
             echo "$IMAGE_FILES"
-            echo "Please convert these files to WebP format."
+            echo "Please convert these files to WebP format. For details, see"
+            echo "https://developer.espressif.com/pages/contribution-guide/writing-content/#use-webp-for-raster-images."
             exit 1
 
           else

--- a/content/blog/making-the-fancy-user-interface-on-esp-has-never-been-easier/index.md
+++ b/content/blog/making-the-fancy-user-interface-on-esp-has-never-been-easier/index.md
@@ -35,7 +35,7 @@ SquareLine studio version 1.1 introduce new feature — __board templates__ . Th
 
 ## ESP Boards in SquareLine Studio
 
-Espressif has prepared two boards in SquareLine Studio for you: [__ESP-BOX__ ](hhttps://github.com/espressif/esp-bsp/tree/master/bsp/esp-box) and [__ESP-WROVER-KIT__ ](https://github.com/espressif/esp-bsp/tree/master/bsp/esp_wrover_kit). You can select the board after launch the application in Create tab and then in Espressif tab (Figure 2). Each board has pre-filled size of screen, rotation and color depth, which is corresponding with [ESP-BSP](https://github.com/espressif/esp-bsp) which is used in generated code.
+Espressif has prepared two boards in SquareLine Studio for you: [__ESP-BOX__ ](https://github.com/espressif/esp-bsp/tree/master/bsp/esp-box) and [__ESP-WROVER-KIT__ ](https://github.com/espressif/esp-bsp/tree/master/bsp/esp_wrover_kit). You can select the board after launch the application in Create tab and then in Espressif tab (Figure 2). Each board has pre-filled size of screen, rotation and color depth, which is corresponding with [ESP-BSP](https://github.com/espressif/esp-bsp) which is used in generated code.
 
 {{< figure
     default=true


### PR DESCRIPTION
## Description

### More recent updates in main

In the `check_links_in_diffs` workflow, the feature branch links are compared to the main branch links. As finalizing changes in a feature branch might take a while, its links get outdated compared to main. This can lead to false positives.

In the proposed updates, the feature branch links are compared to the main branch commit at which the feature branch was created. In this way, the more recent changes in main do not affect link checking.

### Anchors / fragments affected by updates

All links are dumped into `.lycheeignore` from the main branch commit at which the feature branch was created. File names or headings to which the anchor / fragment point might get updated. Yet, checking of fragment links is bypassed. This PR adds steps to identify the files with updated file names and heading titles and removes all links in these files from `.lycheeignore`.

The downside is that if somebody alters a filename of a heading title, all anchor links in this file will be checked anew. On the other hand, if somebody touches an existing file, that would most likely be a maintainer or the author who be in the position to make sure that all links in these files are valid.

### Cleaning up artifacts and any changes to files done in CI 

Also, there were a couple of occasions when the check still failed after corrections were pushed. Creating a new PR with these changes had all checks passed successfully. A culprit might have been a cached file with old links that were not overridden (no other ideas for now). A step has been added to clean up all changes done in CI after the check completes.

## Related

This updates the changes introduced in PR #107. The changes are tracked is issue #101.

## Testing

Tests [run](https://github.com/f-hollow/test-github-releases/pull/16):

- [x] Ensure the workflow does not check main in more recent commits compared to baseline commit
  - Injecting an invalid link in main in a more recent commit should not affect `pr-check-links`
- [x] Ensure that invalid links before the baseline commmit on main do not affect `pr-check-links`
  - Injecting an invalid link in main in the baseline commit should not affect `pr-check-links`
- [x] Ensure that anchors/fragments in a file pointing to heading titles of a file removed or modified in a PR get identified
  - Anchor/fragment links pointing to removed or modified files should not be present in `.lycheeignore`
- [x] Ensure that anchors/fragments in a file pointing to heading titles of a file renamed in a PR get identified
  - Anchor/fragment links pointing to renamed files should not be present in `.lycheeignore`

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
