### PR TITLE
Feat/add workflow preview prs

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,4 +1,4 @@
-name: Deploy Hugo site
+name: Deploy production
 
 on:
   # Run on pushes to the default branch
@@ -8,10 +8,9 @@ on:
   # Allow manual runs from the Actions tab
   workflow_dispatch:
 
-# Set permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Set permissions of the GITHUB_TOKEN
 permissions:
   contents: read
-  pages: write
   id-token: write
 
 # Allow only one concurrent deployment
@@ -68,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Invalidate cloudfront cache
+      - name: Invalidate CloudFront cache
         uses: chetan/invalidate-cloudfront-action@v2
         env:
           PATHS: "/*"

--- a/.github/workflows/pr-deploy-preview.yml
+++ b/.github/workflows/pr-deploy-preview.yml
@@ -1,0 +1,89 @@
+name: Deploy preview for PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  # Allow manual runs from the Actions tab
+  workflow_dispatch:
+
+# Set permissions of the GITHUB_TOKEN
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+# Define environment variables
+env:
+  HUGO_BASEURL: "https://preview-developer.espressif.com/pr${{ github.event.pull_request.number }}/"
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-and-deploy-preview:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Install Hugo CLI
+        env:
+          HUGO_VERSION: 0.135.0
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build website with Hugo
+        env:
+          # For maximum backward compatibility with Hugo modules
+          HUGO_ENVIRONMENT: preview
+          HUGO_ENV: preview
+        run: |
+          hugo \
+            --gc \
+            --minify
+
+      - name: Deploy to AWS S3 PR-specific subdirectory
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --follow-symlinks --delete --cache-control no-cache
+        env:
+          AWS_S3_BUCKET: ${{ secrets.PREVIEW_AWS_BUCKET_NAME }}
+          SOURCE_DIR: './public'
+          # Subdirectory for the PR
+          DEST_DIR: "pr${{ github.event.pull_request.number }}"
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Post Preview Link to PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🎉 A preview of this PR is available at: ${{ env.HUGO_BASEURL }} `
+            })
+
+      - name: Invalidate CloudFront cache for PR
+        uses: chetan/invalidate-cloudfront-action@v2
+        env:
+          PATHS: "/pr-${{ github.event.pull_request.number }}/*"
+          DISTRIBUTION: ${{ secrets.PREVIEW_CLOUDFRONT_DISTRIBUTION }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/pr-remove-preview.yml
+++ b/.github/workflows/pr-remove-preview.yml
@@ -1,0 +1,31 @@
+name: Remove preview for PR
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  remove-preview:
+    name: Remove preview for PR
+    runs-on: ubuntu-latest
+
+    steps:
+      # Remove the PR-specific folder from S3
+      - name: Remove PR-specific subdirectory from S3
+        run: |
+          echo "Cleaning up preview folder for PR #${{ github.event.pull_request.number }}"
+          aws s3 rm "s3://${{ secrets.PREVIEW_AWS_BUCKET_NAME }}/pr${{ github.event.pull_request.number }}" --recursive
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Invalidate CloudFront cache for PR
+        uses: chetan/invalidate-cloudfront-action@v2
+        env:
+          PATHS: "/pr-${{ github.event.pull_request.number }}/*"
+          DISTRIBUTION: ${{ secrets.PREVIEW_CLOUDFRONT_DISTRIBUTION }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -2,9 +2,11 @@
 # Refer to the theme docs for more details about each of these parameters.
 # https://blowfish.page/docs/getting-started/
 
-theme = "blowfish"
-baseURL = "https://developer.espressif.com"
+baseURL = "https://preview-developer.espressif.com/"
+languageCode = "en"
 defaultContentLanguage = "en"
+title = "Espressif Developer Portal Preview"
+theme = "blowfish"
 
 # Keep English on top level
 defaultContentLanguageInSubdir = false
@@ -14,10 +16,8 @@ defaultContentLanguageInSubdir = false
 enableRobotsTXT = true
 summaryLength = 0
 
-buildDrafts = false
-buildFuture = false
-
-googleAnalytics = "G-K9NTMXPGN3"
+buildDrafts = true
+buildFuture = true
 
 [pagination]
   pagerSize = 30

--- a/config/production/hugo.toml
+++ b/config/production/hugo.toml
@@ -1,0 +1,13 @@
+# -- Site Configuration --
+# Refer to the theme docs for more details about each of these parameters.
+# https://blowfish.page/docs/getting-started/
+
+baseURL = "https://developer.espressif.com/"
+title = "Espressif Developer Portal"
+
+buildDrafts = false
+buildFuture = false
+
+[services]
+  [services.googleAnalytics]
+    id = "G-K9NTMXPGN3"

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,9 +1,0 @@
-baseURL = "https://developer.espressif.com/"
-# [en, zh-cn, fr, ...] determines default content language
-defaultContentLanguage = "en"
-# language code
-languageCode = "en"
-title = "Espressif Developer Portal"
-
-# Change the default theme to be use when building the site with Hugo
-theme = "blowfish"


### PR DESCRIPTION
## Description

This PR adds the following workflows:

- `pr-deploy-preview` -- builds a site from the source files in a PR and deploys it to the subfolder `/pr<PR-number>`
  - Example of deployment path: this PR is to be deployed to `https://preview-developer.espressif.com/pr348/`
  - The workflow is triggered when a pull request is open, pushed to, or reopened (after being closed)
- `pr-remove-preview` -- removes the files together with the `/pr<PR-number>` folder earlier deployed by `pr-deploy-preview`
  - The workflow is triggered when a pull request is merged or closed

These workflows can already be used but further improvements can be done:

- :warning: When a PR is created from a fork, require verification by the maintainer before running the preview workflow
- `pr-deploy-preview`
  - On subsequent runs, remove all previously created comments with a preview link
  - Deploy only updated files (see also _Issues syncing files_ in #336)
- On each site page add amessage "Preview, see GitHub PR link..."
- Publish only updated or newly added articles?
- Some links to figures, buttons, get broken (in our case, on the main page) if `baseURL` has subfolders, see related threads
  - [BaseURL path (subdir) sometimes ignored by relURL, absURL](https://discourse.gohugo.io/t/baseurl-path-subdir-sometimes-ignored-by-relurl-absurl/11512)
  - [baseURL with subfolder: why is it not working](https://discourse.gohugo.io/t/baseurl-with-subfolder-why-is-it-not-working/50786)
- For crawlers, that possibly do not respect `robots.txt`, consider adding `nocache`, `noindex` to each site page
  - Consider expanding S3 bucket deploy args to `--cache-control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0"`

Nice to have:

- Add a switch to turn off preview workflows if they are not needed?
- If a user requests a non-existent PR folder (e.g., /pr-999), configure a custom error page

Apart from the covered updates, this PR also introduces separate config files for staging and production environments.

## Related

Issue #43 

## Testing

- Make sure the parameter `--delete` only removes the files in the `DEST_DIR`, and the bucket's root is unaffected
  - Tried redeploying to `DEST_DIR`, other files and folders were unaffected
- Make sure that `robots.txt tester` is not going to crawl HTML pages, otherwise include `noindex` in `<head>`
  - The file `robots.txt` looks correct to prevent crawlers from caching the preview websites
- Test trigger events for the workflows
  - Extensive testing has been done in this PR
- Test if the workflows run successfully when triggered from forked repos
  - Did research and followed he best practices while creating the workflows
  - :warning: Final testing if workflows run smoothly from forked repos can be done immediately after this PR is merged

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
