### PR TITLE
feat: add separate workflows to build and deploy preview pr

### DIFF
--- a/.github/workflows/pr-build-preview.yml
+++ b/.github/workflows/pr-build-preview.yml
@@ -1,0 +1,41 @@
+name: Build preview for PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Hugo CLI
+        env:
+          HUGO_VERSION: 0.135.0
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build website with Hugo
+        env:
+          # For maximum backward compatibility with Hugo modules
+          HUGO_ENVIRONMENT: preview
+          HUGO_ENV: preview
+        run: |
+          hugo \
+            --gc \
+            --minify
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: public-folder
+          path: ./public

--- a/.github/workflows/pr-deploy-preview.yml
+++ b/.github/workflows/pr-deploy-preview.yml
@@ -1,58 +1,36 @@
 name: Deploy preview for PR
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  # Allow manual runs from the Actions tab
-  workflow_dispatch:
+  workflow_run:
+    workflows: ["Build preview for PR"]
+    types:
+      - completed
 
-# Set permissions of the GITHUB_TOKEN
 permissions:
   contents: read
   id-token: write
   pull-requests: write
 
-# Allow only one concurrent deployment
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
-# Define environment variables
 env:
-  HUGO_BASEURL: "https://preview-developer.espressif.com/pr${{ github.event.pull_request.number }}/"
-
-# Default to bash
-defaults:
-  run:
-    shell: bash
+  HUGO_BASEURL: "https://preview-developer.espressif.com/pr${{ github.event.workflow_run.pull_requests[0].number }}/"
 
 jobs:
-  build-and-deploy-preview:
+  deploy-preview:
     runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
 
     steps:
-
-      - name: Install Hugo CLI
-        env:
-          HUGO_VERSION: 0.135.0
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-
-      - name: Check out repo
-        uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
         with:
-          submodules: recursive
-
-      - name: Build website with Hugo
-        env:
-          # For maximum backward compatibility with Hugo modules
-          HUGO_ENVIRONMENT: preview
-          HUGO_ENV: preview
-        run: |
-          hugo \
-            --gc \
-            --minify
+          name: public-folder
+          path: ./public
 
       - name: Deploy to AWS S3 PR-specific subdirectory
         uses: jakejarvis/s3-sync-action@master
@@ -61,8 +39,7 @@ jobs:
         env:
           AWS_S3_BUCKET: ${{ secrets.PREVIEW_AWS_BUCKET_NAME }}
           SOURCE_DIR: './public'
-          # Subdirectory for the PR
-          DEST_DIR: "pr${{ github.event.pull_request.number }}"
+          DEST_DIR: "pr${{ github.event.workflow_run.pull_requests[0].number }}"
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -70,19 +47,19 @@ jobs:
       - name: Post Preview Link to PR
         uses: actions/github-script@v7
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.createComment({
-              issue_number: context.issue.number,
+              issue_number: context.event.workflow_run.pull_requests[0].number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `🎉 A preview of this PR is available at: ${{ env.HUGO_BASEURL }} `
+              body: `🎉 A preview of this PR is available at: ${{ env.HUGO_BASEURL }}`
             })
 
       - name: Invalidate CloudFront cache for PR
         uses: chetan/invalidate-cloudfront-action@v2
         env:
-          PATHS: "/pr-${{ github.event.pull_request.number }}/*"
+          PATHS: "/pr-${{ github.event.workflow_run.pull_requests[0].number }}/*"
           DISTRIBUTION: ${{ secrets.PREVIEW_CLOUDFRONT_DISTRIBUTION }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Description

Following #348 , this PR splits `pr-deploy-preview` into `pr-build-preview` and `pr-deploy-preview` to adjust access permissions so that fork PRs can be deployed for preview safely.

## Related

#348

## Testing

- Testing to be done

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
