### PR TITLE
Ci/change pr check links target branch

### DIFF
--- a/.github/workflows/pr-check-links.yml
+++ b/.github/workflows/pr-check-links.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  TARGET_REPO_URL: https://github.com/espressif/developer-portal.git
+  TARGET_BRANCH: main
+
 jobs:
   check-links:
     runs-on: ubuntu-latest
@@ -18,13 +22,17 @@ jobs:
       - name: Set environment variables
         id: set-env
         run: |
+          # Add target remote and fetch its branches
+          git remote add target ${{ env.TARGET_REPO_URL }}
+          git fetch target ${{ env.TARGET_BRANCH }}
+
           # Extract the base commit ID where the feature branch diverged from main
-          base_commit=$(git merge-base origin/main ${{ github.event.pull_request.head.ref }})
-          echo "base_commit=$base_commit" >> $GITHUB_ENV
+          base_commit=$(git merge-base target/${{ env.TARGET_BRANCH }} ${{ github.event.pull_request.head.ref }})
+          echo "BASE_COMMIT=$base_commit" | tee -a $GITHUB_ENV
 
           # Extract the head commit ID on the feature branch
           head_commit=${{ github.event.pull_request.head.sha }}
-          echo "head_commit=$head_commit" >> $GITHUB_ENV
+          echo "HEAD_COMMIT=$head_commit" | tee -a $GITHUB_ENV
 
       - name: Create baseline branch by reverting feature branch changes
         run: |
@@ -32,7 +40,7 @@ jobs:
           git checkout -b feature-baseline
 
           # Reset the new branch to the base commit
-          git reset --hard ${{ env.base_commit }}
+          git reset --hard ${{ env.BASE_COMMIT }}
 
       - name: Dump all links from feature-baseline
         uses: lycheeverse/lychee-action@v2.0.2
@@ -51,14 +59,11 @@ jobs:
       - name: Append links-baseline.txt to .lycheeignore
         run: cat links-baseline.txt >> .lycheeignore
 
-      - name: Print .lycheeignore
-        run: cat .lycheeignore
-
       - name: Dump names of files altered in PR and append hash sign to find links with anchors
         run: |
-          git diff --name-only --diff-filter=DM ${{ env.base_commit }} ${{ env.head_commit }} > altered-files.txt
+          git diff --name-only --diff-filter=DM ${{ env.BASE_COMMIT }} ${{ env.HEAD_COMMIT }} > altered-files.txt
           sed -i 's|$|#|' altered-files.txt
-          git diff --name-status --diff-filter=R ${{ env.base_commit }} ${{ env.head_commit }} | awk '{print $2}' > renamed-files.txt
+          git diff --name-status --diff-filter=R ${{ env.BASE_COMMIT }} ${{ env.HEAD_COMMIT }} | awk '{print $2}' > renamed-files.txt
           sed -i 's|$|#|' renamed-files.txt
 
       - name: Print altered-files.txt


### PR DESCRIPTION
## Description

The `pr-check-links` has a notion of a _base-commit_. This is a commit at which the feature branch was forked. This commit is determined using the `git merge-base` command. After that, the changes in all subsequent commits are checked by `pr-check-links`.

On numerous occasions (the latest one is #356 and the related [job](https://github.com/espressif/developer-portal/actions/runs/12299931534/job/34326856344?pr=356)), the contributors rebased their feature branch directly against upstream while their fork `origin/main` branch stayed outdated. Due to this, the base commit was determined incorrectly, which resulted in checking links unrelated to the changes in the pull request.

This PR changes the branch against which the base commit is determined from hard-coded `origin/main` to the branch defined by the CI environment variables `TARGET_REPO_URL` and `TARGET_BRANCH`. These variables are set to the `upstream/main` branch.

## Related

- #101 

## Testing

Testing was done in this [testing environment](https://github.com/f-hollow/developer-portal/pull/3).

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
