### PR TITLE
feat: fix invalid dfrobot link

### DIFF
--- a/content/blog/july-2019/index.md
+++ b/content/blog/july-2019/index.md
@@ -61,7 +61,7 @@ Best wishes,John Lee.Senior Customer Support Officer
     src="img/july-3.webp"
     >}}
 
-[DFRobot](https://www.dfrobot.com/index.php?route=information%2Finformation&information_id=4) is an [Espressif](https://www.espressif.com/) partner that specializes in robotics and open-source hardware. They have a product catalog that includes more than a thousand components and widgets, such as sensors, robotic platforms, communication modules, and 3D printers. They have modeled several of their products around [ESP8266](https://www.espressif.com/en/products/hardware/esp8266ex/overview) and [ESP32](https://www.espressif.com/en/products/hardware/esp32/overview), fostering a strong community of IoT learning.
+[DFRobot](https://www.dfrobot.com/topic-302.html) is an [Espressif](https://www.espressif.com/) partner that specializes in robotics and open-source hardware. They have a product catalog that includes more than a thousand components and widgets, such as sensors, robotic platforms, communication modules, and 3D printers. They have modeled several of their products around [ESP8266](https://www.espressif.com/en/products/hardware/esp8266ex/overview) and [ESP32](https://www.espressif.com/en/products/hardware/esp32/overview), fostering a strong community of IoT learning.
 
 ## ESPcopter: An ESP8266-based Programmable Mini Drone
 


### PR DESCRIPTION
## Description

This PR fixes a link that the workflow `Check links in diffs` identifies as a false positive:

`https://www.dfrobot.com/index.php?route=information%2Finformation&information_id=4`

Even though it is, the diffs don't include this change, so this workflow should not report it.

There are two issues that I noticed with regard to this link:

- If `?` is escaped (`\?`), it resolves the issue, but there are many other links with question marks that are not reported... Not sure why it happens yet.
- If I compare checksums of all files in `public/`, the file containing this link was reported as updated, however there were no changes in commits. There might be issues where Hugo updates this file for some reason.

This is not the only case where such things happened:

- Workflow: `https://github.com/espressif/developer-portal/actions/runs/12581829981/job/35066328929`
  - File: `./content/blog/july-2019/index.md`
  - Link: `https://www.dfrobot.com/index.php?route=information%2Finformation&information_id=4`
- Workflow: `https://github.com/espressif/developer-portal/actions/runs/12299931534/job/34326856344`
- Workflow: `https://github.com/espressif/developer-portal/actions/runs/12199519835/job/34035160980`

We need to find a solution to avoid bothering our contributors with such false positives.

## Related

- #101 

## Testing

To be done later

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
