### PR TITLE
fix: update chip support content

### DIFF
--- a/content/pages/chip-support-status/esp32c61/index.md
+++ b/content/pages/chip-support-status/esp32c61/index.md
@@ -35,6 +35,8 @@ If you have an issue to report about any of the ESP32-C61 features, please creat
 {{< chipstatus contentPath="persist/chip-support-status/esp32c61.json" jsonKey="idf" >}}
 
 
-## External projects
+## Other Projects
+
+If you have an issue to report about any of the ESP32-C61 features, please create an issue in the issue tracker of a respective project.
 
 {{< chipstatus contentPath="persist/chip-support-status/esp32c61.json" jsonKey="other_proj" >}}


### PR DESCRIPTION
## Description

This PR returns the content that disappeared during the work on #376 . Preview page: [ESP32-C61 support status](https://preview-developer.espressif.com/pr403/pages/chip-support-status/esp32c61/).

The file `ESP32-C61.md` that is dynamically fetched was sliced up into several types of content. We sliced up a newly-generated file which did not have the manually added lines (the `External project` section) in the previous version of `ESP32-C61.md`.

The dynamically fetched content is not visible. We will implement pulling the latest JSON files from the script repo to previews a bit later.

## Related

- Issue #377 

## Testing

Testing has been done locally.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
