### PR TITLE
fix: correct URL for mirror-main-to-gitlab workflow

### DIFF
--- a/.github/workflows/mirror-main-to-gitlab.yml
+++ b/.github/workflows/mirror-main-to-gitlab.yml
@@ -20,7 +20,7 @@ jobs:
           GITLAB_URL: ${{ secrets.GITLAB_SERVER_URL }}
           GITLAB_TOKEN: ${{ secrets.GITLAB_BOT_REPO_TOKEN }}
           GITLAB_USERNAME: "oauth2"
-          GITLAB_REPO: "https://$GITLAB_URL/espressif/developer-portal.git"
+          GITLAB_REPO: "$GITLAB_URL/espressif/developer-portal.git"
         run: |
           git remote add gitlab https://$GITLAB_USERNAME:$GITLAB_TOKEN@$GITLAB_REPO
           git push gitlab main


### PR DESCRIPTION
## Description

Fix the URL for `mirror-main-to-gitlab.yml`.

## Related

- PR #415 

## Testing

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
