### PR TITLE
fix: correct bad hostname in mirror-main-to-gitlab workflow

### DIFF
--- a/.github/workflows/mirror-main-to-gitlab.yml
+++ b/.github/workflows/mirror-main-to-gitlab.yml
@@ -20,7 +20,7 @@ jobs:
           GITLAB_URL: ${{ secrets.GITLAB_SERVER_URL }}
           GITLAB_TOKEN: ${{ secrets.GITLAB_BOT_REPO_TOKEN }}
           GITLAB_USERNAME: "oauth2"
-          GITLAB_REPO: "$GITLAB_URL/espressif/developer-portal.git"
         run: |
-          git remote add gitlab https://$GITLAB_USERNAME:$GITLAB_TOKEN@$GITLAB_REPO
+          GITLAB_REPO: "$GITLAB_URL/espressif/developer-portal.git"
+          git remote add gitlab "https://$GITLAB_USERNAME:$GITLAB_TOKEN@$GITLAB_REPO"
           git push gitlab main


### PR DESCRIPTION
## Description

This is a fix for another small issue in the `mirror-main-to-gitlab.yml` workflow.

## Related

- PR #415 

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
