### PR TITLE
feat: improve website header layout

### DIFF
--- a/config/_default/languages.cs.toml
+++ b/config/_default/languages.cs.toml
@@ -8,8 +8,6 @@ title = "Developer Portal"
   isoCode = "cs"
   rtl = false
   dateFormat = "2 January 2006"
-  logo = "img/espressif_logo_contour.png"
-  # secondaryLogo = "PATH"
   description = "The developer resources in just one place!"
   # copyright = "Copy, _right?_ :thinking_face:"
 

--- a/config/_default/languages.en.toml
+++ b/config/_default/languages.en.toml
@@ -1,15 +1,13 @@
 languageCode = "en"
 languageName = "English"
 weight = 1
-title = "Espressif Developer Portal"
+title = "Developer Portal"
 
 [params]
   displayName = "EN"
   isoCode = "en"
   rtl = false
   dateFormat = "2 January 2006"
-  logo = "img/espressif_logo_contour.png"
-  # secondaryLogo = "PATH"
   description = "The developer resources in just one place!"
   # copyright = "Copy, _right?_ :thinking_face:"
 

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -17,6 +17,7 @@ mainSections = ["blog"]
 
 disableImageOptimization = false
 disableTextInHeader = false
+logo = "img/espressif_logo_contour.png"
 
 # defaultBackgroundImage = "/img/ocean.jpg"
 # defaultFeaturedImage = "/img/ocean.jpg"

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -1,5 +1,6 @@
 <div style="padding-left:0;padding-right:0;padding-top:2px;padding-bottom:3px"
-    class="main-menu flex items-center justify-between px-4 py-6 sm:px-6 md:justify-start space-x-3">
+    class="main-menu flex flex-wrap items-center justify-between px-4 py-6 sm:px-6 md:justify-start space-x-3">
+
     {{ if .Site.Params.Logo }}
     {{ $logo := resources.Get .Site.Params.Logo }}
     {{ if $logo }}
@@ -18,7 +19,8 @@
     </div>
     {{ end }}
     {{- end }}
-    <div class="flex flex-1 items-center justify-between">
+
+    <div class="flex flex-1 items-center justify-between w-full md:w-auto">
         <nav class="flex space-x-3">
 
             {{ if not .Site.Params.disableTextInHeader | default true }}
@@ -62,9 +64,10 @@
             {{ end }}
 
         </nav>
-        <div class="flex md:hidden items-center space-x-5 md:ml-12">
+    </div>
 
-            <span></span>
+    <div class="w-full flex flex-wrap justify-between md:hidden mt-2 space-y-2">
+        <div class="flex items-center space-x-5 ml-auto">
 
             {{ partial "translations.html" . }}
 
@@ -87,63 +90,59 @@
             </button>
             {{ end }}
 
-        </div>
-    </div>
-    <div class="-my-2 -mr-2 md:hidden">
+            <label id="menu-button" class="block">
+                {{ if .Site.Menus.main }}
+                <div class="cursor-pointer hover:text-primary-600 dark:hover:text-primary-400">
+                    {{ partial "icon.html" "bars" }}
+                </div>
+                <div id="menu-wrapper" style="padding-top:5px;"
+                    class="fixed inset-0 z-30 invisible w-screen h-screen m-0 overflow-auto transition-opacity opacity-0 cursor-default bg-neutral-100/50 backdrop-blur-sm dark:bg-neutral-900/50">
+                    <ul
+                        class="flex space-y-2 mt-3 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none ltr:text-right rtl:text-left max-w-7xl menu-ul">
 
-        <label id="menu-button" class="block">
-            {{ if .Site.Menus.main }}
-            <div class="cursor-pointer hover:text-primary-600 dark:hover:text-primary-400">
-                {{ partial "icon.html" "bars" }}
-            </div>
-            <div id="menu-wrapper" style="padding-top:5px;"
-                class="fixed inset-0 z-30 invisible w-screen h-screen m-0 overflow-auto transition-opacity opacity-0 cursor-default bg-neutral-100/50 backdrop-blur-sm dark:bg-neutral-900/50">
-                <ul
-                    class="flex space-y-2 mt-3 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none ltr:text-right rtl:text-left max-w-7xl menu-ul">
-
-                    <li id="menu-close-button">
-                        <span
-                            class="cursor-pointer inline-block align-text-bottom hover:text-primary-600 dark:hover:text-primary-400 menu-close">{{
-                            partial
-                            "icon.html"
-                            "xmark" }}</span>
-                    </li>
-
-                    {{ range .Site.Menus.main }}
-
-                    {{ partial "header/header-mobile-option.html" . }}
-
-                    {{ end }}
-
-                </ul>
-                {{ if .Site.Menus.subnavigation }}
-                <hr>
-                <ul
-                    class="flex mt-4 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none ltr:text-right rtl:text-left max-w-7xl">
-
-
-                    {{ range .Site.Menus.subnavigation }}
-                    <li class="mb-1">
-                        <a href="{{ .URL }}" {{ if or (strings.HasPrefix .URL "http:" ) (strings.HasPrefix .URL "https:"
-                            ) }} target="_blank" {{ end }} class="flex items-center">
-                            {{ if .Pre }}
-                            <span {{ if and .Pre .Name}} class="mr-3" {{ end }}>
-                                {{ partial "icon.html" .Pre }}
+                        <li id="menu-close-button">
+                            <span
+                                class="cursor-pointer inline-block align-text-bottom hover:text-primary-600 dark:hover:text-primary-400 menu-close">{{
+                                partial "icon.html" "xmark" }}
                             </span>
-                            {{ end }}
-                            <p class="text-sm font-sm text-gray-500 hover:text-gray-900" title="{{ .Title }}">
-                                {{ .Name | markdownify | emojify }}
-                            </p>
-                        </a>
-                    </li>
+                        </li>
+
+                        {{ range .Site.Menus.main }}
+
+                        {{ partial "header/header-mobile-option.html" . }}
+
+                        {{ end }}
+
+                    </ul>
+                    {{ if .Site.Menus.subnavigation }}
+                    <hr>
+                    <ul
+                        class="flex mt-4 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none ltr:text-right rtl:text-left max-w-7xl">
+
+
+                        {{ range .Site.Menus.subnavigation }}
+                        <li class="mb-1">
+                            <a href="{{ .URL }}" {{ if or (strings.HasPrefix .URL "http:" ) (strings.HasPrefix .URL "https:"
+                                ) }} target="_blank" {{ end }} class="flex items-center">
+                                {{ if .Pre }}
+                                <span {{ if and .Pre .Name}} class="mr-3" {{ end }}>
+                                    {{ partial "icon.html" .Pre }}
+                                </span>
+                                {{ end }}
+                                <p class="text-sm font-sm text-gray-500 hover:text-gray-900" title="{{ .Title }}">
+                                    {{ .Name | markdownify | emojify }}
+                                </p>
+                            </a>
+                        </li>
+                        {{ end }}
+
+                    </ul>
+                    {{ end }}
                     {{ end }}
 
-                </ul>
-                {{ end }}
-                {{ end }}
-
-            </div>
-        </label>
+                </div>
+            </label>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
## Description

This PR improves the Developer Portal's header layout.

To preview how it looks on a mobile device, use your browser's mobile view mode. For example, Firefox has the the [Responsive Design Mode](https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/).

However, the CI job adds a link back to this PR in the header of the preview website. Maybe the best way to visualize the header changes is on your local machine.

### What has been updated

- The string `Espressif Developer Portal` in the header was reduced to `Developer Portal`. This saves horizontal space and removes the duplication of the word _Espressif_  in the logo and `Espressif Developer Portal` 
- The burger menu, search button, and language switch (also the hidden dark/light theme appearance) will appear in the second row aligned to the right.

### Follow-up actions

See issue #161.

## Related

- Issue #161 

## Testing

Done locally.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
