### PR TITLE
ci: split link checking into multiple jobs

### DIFF
--- a/.github/workflows/mirror-main-to-gitlab.yml
+++ b/.github/workflows/mirror-main-to-gitlab.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   mirror:
+    if: github.repository_owner == 'espressif'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/pr-check-links-caller.yml
+++ b/.github/workflows/pr-check-links-caller.yml
@@ -1,0 +1,24 @@
+name: Check links in diffs
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-links:
+    strategy:
+      matrix:
+        include:
+          - glob_pattern: "--exclude-path content/blog/ ./content/ README.md"
+            job_name: "non-blog"
+          - glob_pattern: "./content/blog/[0-9a-f]*/"
+            job_name: "blog_0-9a-f"
+          - glob_pattern: "./content/blog/[g-z]*/"
+            job_name: "blog_g-z"
+      fail-fast: false
+    name: ${{ matrix.job_name }}
+    uses: ./.github/workflows/pr-check-links-worker.yml
+    with:
+      glob_pattern: ${{ matrix.glob_pattern }}
+      target_repo_url: "https://github.com/espressif/developer-portal.git"
+      target_branch: "main"

--- a/.github/workflows/pr-check-links-worker.yml
+++ b/.github/workflows/pr-check-links-worker.yml
@@ -1,12 +1,17 @@
-name: Check links in diffs
+name: Check links worker
 
 on:
-  pull_request:
-    branches: [main]
-
-env:
-  TARGET_REPO_URL: https://github.com/espressif/developer-portal.git
-  TARGET_BRANCH: main
+  workflow_call:
+    inputs:
+      glob_pattern:
+        required: true
+        type: string
+      target_repo_url:
+        required: true
+        type: string
+      target_branch:
+        required: true
+        type: string
 
 jobs:
   check-links:
@@ -23,11 +28,11 @@ jobs:
         id: set-env
         run: |
           # Add target remote and fetch its branches
-          git remote add target ${{ env.TARGET_REPO_URL }}
-          git fetch target ${{ env.TARGET_BRANCH }}
+          git remote add target ${{ inputs.target_repo_url }}
+          git fetch target ${{ inputs.target_branch }}
 
           # Extract the base commit ID where the feature branch diverged from main
-          base_commit=$(git merge-base target/${{ env.TARGET_BRANCH }} ${{ github.event.pull_request.head.ref }})
+          base_commit=$(git merge-base target/${{ inputs.target_branch }} ${{ github.event.pull_request.head.ref }})
           echo "BASE_COMMIT=$base_commit" | tee -a $GITHUB_ENV
 
           # Extract the head commit ID on the feature branch
@@ -48,9 +53,8 @@ jobs:
           args: |
             --dump
             --include-fragments
-            --exclude-path ./themes/
-            --exclude-path ./layouts/
-            .
+            --glob-ignore-case
+            ${{ inputs.glob_pattern }}
           output: links-baseline.txt
 
       - name: Check out feature branch
@@ -93,9 +97,8 @@ jobs:
           args: |
             --no-progress
             --include-fragments
-            --exclude-path ./themes/
-            --exclude-path ./layouts/
-            .
+            --glob-ignore-case
+            ${{ inputs.glob_pattern }}
           fail: true  # Fail action if broken links are found
 
       - name: Suggestions

--- a/content/blog/espressif-devkits-with-wsl2/index.md
+++ b/content/blog/espressif-devkits-with-wsl2/index.md
@@ -17,7 +17,7 @@ This article is a step-by-step guide, provided to help you work with Espressif's
 
 ### Alternatives
 
-Many common operations (e.g., flashing, monitoring, etc. ) can be handled by the [ESP_RFC2217_server](https://docs.espressif.com/projects/esptool/en/latest/esp32/esptool/remote-serial-ports.html) (Telnet) where the host Windows machine acts as the server and the WSL terminal acts as the client. However, tools like [OpenOCD](https://openocd.org/) (Open On-Chip Debugger) cannot be used with this approach.
+Many common operations (e.g., flashing, monitoring, etc. ) can be handled by the [ESP_RFC2217_server](https://docs.espressif.com/projects/esptool/en/latest/esp32/remote-serial-ports.html) (Telnet) where the host Windows machine acts as the server and the WSL terminal acts as the client. However, tools like [OpenOCD](https://openocd.org/) (Open On-Chip Debugger) cannot be used with this approach.
 
 ## Guide
 

--- a/content/blog/espressif-socs-lcd-screens/index.md
+++ b/content/blog/espressif-socs-lcd-screens/index.md
@@ -82,7 +82,7 @@ This development board is an excellent choice for evaluating and building protot
 
 The RGB interface is known for its high brush rate, making it ideal for controlling large screens. Its broad application range allows it to support various display sizes and resolutions, ensuring smooth and responsive graphical user interfaces (GUIs).
 
-For applications using the RGB interface, the [ESP32-S3](https://www.espressif.com.cn/en/products/socs/esp32-s3) SoC is recommended. This SoC is suitable for several smart and interactive applications:
+For applications using the RGB interface, the [ESP32-S3](https://www.espressif.com/en/products/socs/esp32-s3) SoC is recommended. This SoC is suitable for several smart and interactive applications:
 
 - **Smart Home Interfaces**: This includes various types of control panels such as device control panels, light switch panels, scene controllers, and temperature management panels.
 - **Interactive Remote Controls**: Remote controls designed with responsive and engaging displays for improved user interaction.
@@ -115,7 +115,7 @@ The recommended development boards for building prototypes are as follows:
 
 The SPI interface is well-suited for small screens and low-resolution displays due to its simplicity and cost-effectiveness. It is particularly efficient for small display applications with basic graphical needs. In other words, it is good for straightforward and economical solutions.
 
-For applications using the SPI interface, the [ESP32-C3](https://www.espressif.com.cn/en/products/socs/esp32-c3) and [ESP32-C6](https://www.espressif.com.cn/en/products/socs/esp32-c6) SoCs are recommended. These SoCs are suitable for the following applications:
+For applications using the SPI interface, the [ESP32-C3](https://www.espressif.com/en/products/socs/esp32-c3) and [ESP32-C6](https://www.espressif.com/en/products/socs/esp32-c6) SoCs are recommended. These SoCs are suitable for the following applications:
 
 - **Household Appliances**: Washing machines, body fat scales, personal health devices, electric toothbrushes.
 - **Small Display Devices**: Knob screens, compact displays used in various consumer electronics.

--- a/content/blog/november-2018/index.md
+++ b/content/blog/november-2018/index.md
@@ -46,7 +46,7 @@ Senior Customer Support Officer
     src="img/november-2.webp"
     >}}
 
-Espressif’s distributor in Japan, [Midoriya Electric](https://www.midoriya.co.jp/eng/), participated in the 4th IoT/M2M Expo, in Makuhari Messe, which took place on October 24–26. This was part of Japan’s [IT Week](https://www.japan-it.jp/ja-jp.html), which is a world-leading IT show that has become the most comprehensive business-to-business IT exhibition in Japan. This year the show was the biggest one in its history, in terms of the number of exhibitors and professional visitors from the industry.  asdf
+Espressif’s distributor in Japan, [Midoriya Electric](https://www.midoriya.co.jp/eng/), participated in the 4th IoT/M2M Expo, in Makuhari Messe, which took place on October 24–26. This was part of Japan’s [IT Week](https://www.japan-it.jp/hub/en-gb.html), which is a world-leading IT show that has become the most comprehensive business-to-business IT exhibition in Japan. This year the show was the biggest one in its history, in terms of the number of exhibitors and professional visitors from the industry.  asdf
 
 [Keep Reading](https://www.espressif.com/en/news/Espressif_Solutions_at_Japans_4th_IoT_M2M_Expo)
 

--- a/content/blog/november-2020/index.md
+++ b/content/blog/november-2020/index.md
@@ -31,7 +31,7 @@ On a different note, [IOT2TANGLE’s hackathon](https://i2t.medium.com/the-integ
 
 We’re really excited that dozens of registered projects have been submitted by __contestants from all around the world__ , e.g. from Argentina, Brazil, Canada, Denmark, Germany, India, Indonesia, Italy, Peru, Switzerland, the United States, and many other countries. [This hackathon, entitled “Integrate Everything with IOTA”](https://youtu.be/BI_p3Bg7ZGE), aims to generate quality open-source integrations that will be valuable stepping-stones for subsequent development projects that connect IoT devices with Distributed Ledger Technologies.
 
-__*Good luck to all the participants!*__ 
+__*Good luck to all the participants!*__
 
 {{< figure
     default=true
@@ -56,7 +56,7 @@ ESP32-C3 is a single-core Wi-Fi and Bluetooth LE 5.0 microcontroller unit, based
     src="img/november-5.webp"
     >}}
 
-Our new [ESP Product Selector](http://products.espressif.com/) is an online tool designed to increase development efficiency and reduce the time for business communication. To use it, customers do not need to register with us or download the tool. All they need to do is click on the link and use it, taking advantage of its simple function and multiple benefits.
+Our new [ESP Product Selector](https://products.espressif.com/) is an online tool designed to increase development efficiency and reduce the time for business communication. To use it, customers do not need to register with us or download the tool. All they need to do is click on the link and use it, taking advantage of its simple function and multiple benefits.
 
 [__Aimagin’s ESP32-powered Waijung 2 Released__ ](https://www.espressif.com/en/news/ESP32_Waijung)
 


### PR DESCRIPTION
## Description

Once `pr-check-links` is run, GitHub CI started returning `Error: Compiled regex exceeds size limit of 10485760 bytes.`.

Apparently, the file `.lycheeignore` contains too many entries causing lychee to construct an oversized regex.

I tried several solutions:

- Tried using `--exclude` for links instead of `.lycheeignore`,however, the pipeline resulted in [failure](https://github.com/f-hollow/developer-portal/actions/runs/13806056036/job/38616947549?pr=8).
- Tried other countless fixes invain

The only working solution appeared to be splitting link checking into several stages:

- `non-blog` - all files in `./content` except for `./content/blog/` and `README.md`
- `blog_0-9a-f` - all files in `./content/blog/[0-9a-f]*/` folders
- `blog_g-z`- all files in `./content/blog/[g-z]*/` folders

## Related

- Issue #101 

## Testing

Extensive testing was done in the [testing environment](https://github.com/f-hollow/developer-portal/pull/8).

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
