### PR TITLE
Feat/lint using vale

### DIFF
--- a/.github/workflows/pr-lint-vale.yml
+++ b/.github/workflows/pr-lint-vale.yml
@@ -1,0 +1,13 @@
+name: reviewdog
+on: [pull_request]
+
+jobs:
+  vale:
+    name: runner / vale
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: errata-ai/vale-action@v2.1.1
+        with:
+          reporter: github-pr-check
+          fail_on_error: true

--- a/.github/workflows/pr-lint-vale.yml
+++ b/.github/workflows/pr-lint-vale.yml
@@ -10,4 +10,5 @@ jobs:
       - uses: errata-ai/vale-action@v2.1.1
         with:
           reporter: github-pr-check
+          vale_flags: "--minAlertLevel=suggestion"
           fail_on_error: true

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,127 @@
+###################
+### Vale Config ###
+###################
+
+# This is a Vale linter configuration file.
+# - Repo: esp-vale-config (Default config)
+# - Version: v0-1-1
+# It lists all necessary parameters to configure Vale for your project.
+# For official documentation on all config settings, see
+# https://vale.sh/docs/topics/config
+
+
+##############
+### Global ###
+##############
+
+# This section lists core settings applying to Vale itself.
+
+
+# Specify path to external resources (e.g., styles and vocab files).
+# The path value may be absolute or relative to this configuration file.
+StylesPath = .vale/styles
+
+
+# Specify the minimum alert severity that Vale will report.
+MinAlertLevel = suggestion # "suggestion", "warning", or "error"
+
+
+# Specify vocabulary for special treatment.
+# Create a folder in <StylesPath>/Vocab/<name>/and add its name here
+# The folder should contain two files:
+# - accept.txt -- lists words with accepted case-sensitive spelling
+# - reject.txt -- lists words whose occurrences throw an error
+# Vocab = Espressif
+
+
+# Specify the packages to import into your project.
+# A package is a zip file containing a number of rules (style) written in YAML.
+# For a list of official packages, see Package Hub at https://vale.sh/hub/
+# For official documentation on packages, see
+# https://vale.sh/docs/topics/packages/
+# Before linting, navigate to your project and run `vale sync` to download
+# the official packages specified below.
+# Packages = Package1, Package2, \
+# https://example.com/path/to/package/Package.zip
+Packages = Google, Microsoft, RedHat, \
+https://dl.espressif.com/dl/esp-vale-config/Espressif-latest.zip
+
+
+###############
+### Formats ###
+###############
+
+# This section enables association of "unknown" formats with the ones
+# supported by Vale. For official documentation on supported formats, see
+# https://vale.sh/docs/topics/scoping/
+[formats]
+
+# For example, treat MDX files as Markdown files.
+# mdx = md
+
+
+################################
+### Format-specific settings ###
+################################
+
+# This section lists the settings that apply to specific file formats
+# based on their glob pattern.
+# Settings provided under a more specific glob pattern,
+# such as [*.{md,txt}] will override those in [*].
+[*.{md,rst}]
+
+
+# Enable styles to activate all rules included in them.
+# BasedOnStyles = Style1, Style2
+BasedOnStyles = Vale, Espressif-latest, Espressif-devportal
+
+
+### Deactivate individual rules ###
+### in enabled styles.
+# Style1.Rule1 = NO
+Vale.Repetition = NO
+Vale.Spelling = NO
+Espressif-latest.Admonitions = NO
+Espressif-latest.Adverbs = NO
+Espressif-latest.Contractions = NO
+Espressif-latest.HeadingBegin = NO
+Espressif-latest.HeadingEnd = NO
+Espressif-latest.Headings = NO
+Espressif-latest.Monospace = NO
+Espressif-latest.PascalCamelCase = NO
+Espressif-latest.TermsAcronyms = NO
+Espressif-latest.TermsFixedPattern = NO
+Espressif-latest.TermsSingleCorrectSpelling = NO
+
+
+### Change default severity level ###
+### of an activated rule.
+# Choose between "suggestion", "warning", or "error".
+# Style1.Rule2 = error
+
+
+### Activate individual rules ###
+### in non-enabled styles stored in <StylesPath>.
+# Style1.Rule = YES
+Google.Gender = YES
+Google.GenderBias = YES
+Google.Slang = YES
+Google.Spacing = YES
+Microsoft.DateNumbers = YES
+Microsoft.Ellipses = YES
+#Microsoft.FirstPerson = YES
+Microsoft.Hyphens = YES
+Microsoft.Ordinal = YES
+#Microsoft.OxfordComma = YES
+Microsoft.Percentages = YES
+#Microsoft.Quotes = YES
+Microsoft.RangeTime = YES
+Microsoft.Semicolon = YES
+#Microsoft.SentenceLength = YES
+Microsoft.Suspended = YES
+Microsoft.Units = YES
+Microsoft.URLFormat = YES
+#Microsoft.We = YES
+Microsoft.Wordiness = YES
+#RedHat.Contractions = YES
+RedHat.RepeatedWords = YES

--- a/.vale/styles/Espressif-devportal/HeadingSentenceCase.yml
+++ b/.vale/styles/Espressif-devportal/HeadingSentenceCase.yml
@@ -1,0 +1,168 @@
+---
+extends: capitalization
+level: suggestion
+link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/headings/
+match: $sentence
+message: "Use sentence-style capitalization. Found: '%s'. Suggested: '%s'. Ensure that proper nouns and noun phrases are capitalized correctly."
+scope: heading
+indicators:
+  - ":"
+exceptions:
+
+# Espressif
+  - Espressif
+  - Xtensa
+  - RISC-V
+  - Wokwi
+  - 'Developer Portal'
+  - DevKit
+  - SoCs?
+  - (?i)VSCode
+  - (?i)FreeRTOS
+  - eFuses?
+  - \bESP[-A-Za-z0-9_]*\b
+  - Rainmaker
+  - LowCode
+  - ZeroCode
+
+# Embedded
+  - ADC
+  - AIoT
+  - DAC
+  - IoT
+  - Matter
+  - PHY
+  - PSRAM
+  - RAM
+  - SRAM
+  - WLED
+
+# Rust
+  - 'Rust'
+  - 'std'
+  - 'no_std'
+
+# Measurement Units
+  - kbps|Mbps|Gbps
+  - KiB|MiB|GiB
+  - kHz|MHz|GHz
+  - dBm|dBu|dBV
+
+# General
+  - Ansible
+  - Antora
+  - API
+  - AppData
+  - AsciiDoc
+  - Asciidoctor
+  - AWS
+  - Azure
+  - BASIC
+  - Bitbucket
+  - BOM
+  - Bugzilla
+  - CDs
+  - CentOS
+  - Ceph
+  - CLI
+  - Clion
+  - CMake
+  - Copilot
+  - DdoS
+  - DevOps
+  - DevOps
+  - DNS
+  - DNSSec
+  - Docker
+  - Dockerfiles?
+  - Eclipse
+  - Flatpak
+  - Flatpak Builder
+  - GCC
+  - Git
+  - GitHub
+  - GitLab
+  - GitOps
+  - GraphQL
+  - GUI
+  - Homebrew
+  - HTTP
+  - HTTPS
+  - IaaS
+  - IBM
+  - ID
+  - IDEs?
+  - IDs
+  - IntelliJ
+  - IPSec
+  - JAR file
+  - Java
+  - JavaScript
+  - JetBrains
+  - Jira
+  - JSON
+  - Kubernetes
+  - LibreOffice
+  - Linux
+  - LLVM
+  - Lua
+  - MAC
+  - macOS
+  - Makefile
+  - Mattermost
+  - MicroPython
+  - Microsoft
+  - MinGW
+  - MongoDB
+  - MySQL
+  - NetworkManager
+  - Nginx
+  - Node.js
+  - NuttX
+  - NVMe
+  - OAuth
+  - OpenJDK
+  - OpenOCD
+  - OpenShift
+  - OpenSSH
+  - OpenSSL
+  - OpenStack
+  - OpenTelemetry
+  - OpenTracing
+  - PCIe
+  - PHP
+  - Podman
+  - POSIX
+  - PostgreSQL
+  - PostScript
+  - PowerShell
+  - Prometheus
+  - Python
+  - Pytorch
+  - Qt
+  - Qute
+  - Red Hat
+  - Redis
+  - RTOS
+  - SaaS
+  - SDK
+  - SELinux
+  - Studio
+  - SVG
+  - SysV
+  - Traefik
+  - TypeScript
+  - URI
+  - URIs?
+  - URLs?
+  - USB
+  - Vale
+  - Vmware
+  - VS
+  - VS Code
+  - WebSocket
+  - Windows
+  - WireGuard
+  - Wordpress
+  - xterm
+  - YouTube

--- a/.vale/styles/Espressif-devportal/ListEndPunctuation.yml
+++ b/.vale/styles/Espressif-devportal/ListEndPunctuation.yml
@@ -1,0 +1,19 @@
+extends: existence
+message: "Ensure consistent punctuation in lists. Some items end with punctuation while others don't."
+level: warning
+link: https://mos.espressif.com/punctuation.html#punctuation-in-lists
+scope: raw
+nonword: true
+tokens:
+  # Find bulleted lists with inconsistent punctuation
+  - '(?m)^[\-\+\*]\s.*\w(?<![.!?:;])$\n{1,2}[\-\+\*]\s.*\w[.!?:;]$'
+  - '(?m)^[\-\+\*]\s.*\w[.!?:;]$\n{1,2}[\-\+\*]\s.*\w(?<![.!?:;])$'
+  # Find numbered lists with inconsistent punctuation
+  - '(?m)^\d+\.\s.*\w(?<![.!?:;])$\n{1,2}\d+\.\s.*\w[.!?:;]$'
+  - '(?m)^\d+\.\s.*\w[.!?:;]$\n{1,2}\d+\.\s.*\w(?<![.!?:;])$'
+  # Find bulleted sublists with inconsistent punctuation
+  - '(?m)^[ ]{2,4}[\-\+\*]\s.*\w(?<![.!?:;])$\n{1,2}[ ]{2,4}[\-\+\*]\s.*\w[.!?:;]$'
+  - '(?m)^[ ]{2,4}[\-\+\*]\s.*\w[.!?:;]$\n{1,2}[ ]{2,4}[\-\+\*]\s.*\w(?<![.!?:;])$'
+  # Find numbered sublists with inconsistent punctuation
+  - '(?m)^[ ]{2,4}\d+\.\s.*\w(?<![.!?:;])$\n{1,2}[ ]{2,4}\d+\.\s.*\w[.!?:;]$'
+  - '(?m)^[ ]{2,4}\d+\.\s.*\w[.!?:;]$\n{1,2}[ ]{2,4}\d+\.\s.*\w(?<![.!?:;])$'

--- a/.vale/styles/Espressif-devportal/ListMixedType.yml
+++ b/.vale/styles/Espressif-devportal/ListMixedType.yml
@@ -1,0 +1,12 @@
+extends: existence
+message: "Don't mix bulleted and numbered lists at the same level."
+level: warning
+scope: raw
+nonword: true
+tokens:
+  # Find lists with bullets and numbers at the same level
+  - '(?m)^[\-\+\*]\s.*$\n{1,2}\d+\.\s.*$'
+  - '(?m)^\d+\.\s.*$\n{1,2}[\-\+\*]\s.*$'
+  # Find sublists with bullets and numbers at the same level
+  - '(?m)^[ ]{2,4}[\-\+\*]\s.*$\n{1,2}[ ]{2,4}\d+\.\s.*$'
+  - '(?m)^[ ]{2,4}\d+\.\s.*$\n{1,2}[ ]{2,4}[\-\+\*]\s.*$'

--- a/.vale/styles/Espressif-devportal/NonStandardChars.yml
+++ b/.vale/styles/Espressif-devportal/NonStandardChars.yml
@@ -1,0 +1,11 @@
+extends: substitution
+message: Do not use non-standard symbols. Use %s rather than %s.
+level: warning
+nonword: true
+scope: raw
+action:
+  name: replace
+swap:
+  ‘|’: "'"
+  ‟|″|‶: "\""
+  –|—: "--"

--- a/.vale/styles/Espressif-devportal/OfxordComma.yml
+++ b/.vale/styles/Espressif-devportal/OfxordComma.yml
@@ -1,0 +1,8 @@
+extends: existence
+message: "Use the Oxford comma in '%s'."
+link: https://mos.espressif.com/punctuation.html#intricacies-of-using-the-oxford-comma
+scope: text
+level: suggestion
+nonword: true
+tokens:
+  - '(?:\b[\w-`]+(?: [\w-`]+)?, ){1,}[\w-`]+ (and|or) [\w-`]+\b'

--- a/.vale/styles/Espressif-devportal/TermsAcronyms.yml
+++ b/.vale/styles/Espressif-devportal/TermsAcronyms.yml
@@ -1,0 +1,142 @@
+# Google.Acronyms -- customized
+# For details, see Espressif Vale Config Documentation
+extends: conditional
+message: "Spell out '%s' if it's unfamiliar to the audience."
+# source: EMoS > Define Abbreviations and Acronyms at First Use
+link: http://mos.espressif.com/general-conventions.html#define-abbreviations-and-acronyms-at-first-use
+level: warning
+# Ensures that the existence of 'first' implies the existence of 'second'.
+first: '(?<!\w|\-)\b([A-Z]{3,5})\b(?!\w|\-)'
+second: '(?:\b[A-Za-z][a-z]+ )+\(([A-Z]{3,5})\)'
+# ... with the exception of these:
+exceptions:
+
+# Espressif
+  - MINI
+  - WROOM
+  - RainMaker
+
+# Embedded
+  - ACK
+  - ADC
+  - DAC
+  - GPIO
+  - I2C
+  - I2S
+  - LSB
+  - MSB
+  - MTDO
+  - MTDI
+  - MTCK
+  - MTMS
+  - NACK
+  - OTA
+  - PCB
+  - PHY
+  - PSRAM
+  - RAM
+  - RTOS
+  - SCL
+  - SDA
+  - SPI
+  - SRAM
+  - START
+  - TDO
+  - TDI
+  - TCK
+  - TMS
+  - UART
+  - WLED
+  - 3V3
+
+# False positives
+  - NOTE
+  - RISC
+  - RUST
+  - TODO
+  - WIFI
+
+# Rust
+  - ABI
+  - BLE
+  - ELF
+  - HAL
+  - MQTT
+  - MSVC
+  - NOW
+  - PAC
+  - RTC
+  - VJTAG
+  - LLDB
+  - IMU
+
+# General
+
+  - AI
+  - AI[Oo]T
+  - API
+  - ASCII
+  - AWS
+  - BASIC
+  - BIOS
+  - CLI
+  - CMOS
+  - CPU
+  - CSS
+  - CSV
+  - DPI
+  - ESP
+  - FAQ
+  - GCC
+  - GDB
+  - GET
+  - GND
+  - GNU
+  - GPS
+  - GPU
+  - GUI
+  - HTML
+  - HTTP
+  - HTTPS
+  - IDE
+  - IDF
+  - IEEE
+#  - JAR
+  - I[Oo]T
+  - JSON
+  - JTAG
+  - LED
+  - LLVM
+  - MAC
+  - MCU
+  - MIT
+  - NET
+  - PATH
+  - PDF
+  - PHP
+  - POSIX
+  - POST
+  - PUT
+  - QEMU
+  - RAM
+  - RFC
+  - RGB
+  - ROM
+  - RSA
+  - SDK
+  - SQL
+  - SSH
+  - SSID
+  - SSL
+  - SVG
+  - TBD
+  - TCP
+  - TOML
+  - URI
+  - URL
+  - USB
+  - UTF
+  - UUID
+  - XML
+  - YAML
+  - ZIP

--- a/.vale/styles/Espressif-devportal/TermsFixedPattern.yml
+++ b/.vale/styles/Espressif-devportal/TermsFixedPattern.yml
@@ -1,0 +1,11 @@
+# Newly-created rule at Espressif
+# For details, see Espressif Vale Config Documentation
+extends: substitution
+message: '%s (now: %s)'
+ignorecase: false
+level: warning
+# source: "Espressif Term Base"
+swap:
+  802.11\s\w.?\/\w: Remove space between '802.11' and 'x/x/x'
+  SOCs?: Use 'SoC' or 'SoCs' instead
+  #'ESP [Dd]evices?|ESP [Pp]roducts?': Use 'Espressif devices' or 'Espressif products'

--- a/.vale/styles/Espressif-devportal/TermsSingleCorrectSpelling.yml
+++ b/.vale/styles/Espressif-devportal/TermsSingleCorrectSpelling.yml
@@ -1,0 +1,32 @@
+# Newly-created rule at Espressif
+# For details, see Espressif Vale Config Documentation
+extends: substitution
+message: "Use '%s' instead of '%s'."
+ignorecase: true
+level: suggestion
+link: https://github.com/esp-rs/book/blob/main/rust-doc-style-guide.md#recommended-terms
+action:
+  name: replace
+swap:
+  vs\s?code:            VS Code
+  mac\s?OS:             macOS
+  bluetooth:            Bluetooth
+  efuse:                eFuse
+  aiot:                 AIoT
+  freeRTOS:             FreeRTOS
+  IOT:                  IoT
+  #unix:                UNIX
+  ibus:                 IBUS
+  dbus:                 DBUS
+  wi-?fi:               Wi-Fi
+  cargo:                Cargo
+  dev\s?containers?:    Dev Container(s)
+  openocd:              OpenOCD
+  clion:                CLion
+  mingw:                MinGW
+  esp-idf programming guide: ESP-IDF Programming Guide
+  rainmaker:            RainMaker
+  copilot:              Copilot
+  esp\slowcode:         ESP LowCode
+  esp\szerocode:        ESP ZeroCode
+  co-processor:         coprocessor

--- a/.vale/styles/Espressif-devportal/UsefulLinkText.yml
+++ b/.vale/styles/Espressif-devportal/UsefulLinkText.yml
@@ -1,0 +1,19 @@
+extends: existence
+message: "Avoid '%s' in link text. Use a couple of keywords instead to describe WHAT the link leads to. In the surrouding text, explain WHY this link is given or HOW it helps."
+level: warning
+link: https://technicalwriting.dev/links/automation.html#background
+scope: raw
+ignorecase: true
+tokens:
+  # Check md links [here](http://example.com)
+  - '(?<=\[)(?:\b(?:in|on|at)\s+)?(here|click here|this page|this link|read more|learn more)(?=\]\(.*\))'
+  # Check md links with numeric ref [here][1]
+  - '(?<=\[)(?:\b(?:in|on|at)\s+)?(here|click here|this page|this link|read more|learn more)(?=\]\[\d+\])'
+  # Check md links with named ref [here][example]
+  - '(?<=\[)(?:\b(?:in|on|at)\s+)?(here|click here|this page|this link|read more|learn more)(?=\]\[[^\]]+\])'
+  # Check md links with empty ref [here][]
+  - '(?<=\[)(?:\b(?:in|on|at)\s+)?(here|click here|this page|this link|read more|learn more)(?=\]\[\])'
+  # Check rST hyperlinks `here <http://example.com>`_
+  - '(?<=`)(?:\b(?:in|on|at)\s+)?(here|click here|this page|this link|read more|learn more)(?= <[^>]+>`_)'
+  # Check rST internal refs :ref:`here<Heading Text>`
+  - '(?<=:ref:`)(?:\b(?:in|on|at)\s+)?(here|click here|this page|this link|read more|learn more)(?=<[^`>]+>`)'

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Rule `Espressif-devportal.HeadingSentenceCase`
 
 #### Use Sentence Style Capitalization
 
-#### Exceptions for capitalization can be added like espressif
+#### Exceptions for capitalization can be added like Espressif
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This project stores the files for the [Espressif Developer Portal][] website. Gi
 
 [Espressif Developer Portal]: https://developer.espressif.com/
 
+This doesn't works. See [this](./content/blog/2025/03/esp32-bluetooth-clearing-the-air/index.md#impat).
+
+For details, see the page [at this link](https://google.com).
 
 ## Contribute and render locally
 
@@ -17,3 +20,66 @@ See also the Contribution Guide articles:
 
 - [Contribution workflow](./content/pages/contribution-guide/contrib-workflow/index.md)
 - [Writing content](./content/pages/contribution-guide/writing-content/index.md)
+
+## Test Vale style
+
+---
+
+Rule `Espressif-devportal.HeadingSentenceCase`
+
+#### Use Sentence Style Capitalization
+
+#### Exceptions for capitalization can be added like espressif
+
+---
+
+Rules `Espressif-devportal.ListEndPunctuation` and `Espressif-devportal.ListMixedType`
+
+Simple bullet list:
+
+- Item 1
+- Item 2.
+
+Multi-level list:
+
+1. Item 1:
+2. Item 2
+  - Item 1.
+  - Item 2
+
+Bullets and numbers at the same level:
+
+1. Item 1
+- Item 2
+
+---
+
+Rule `Espressif-devportal.NonStandardChars`
+
+The modules–those that integrate SoCs–are more popular.
+
+---
+
+Rule `Espressif-devportal.OfxordComma`
+
+Espressif is famous for its SoCs, modules and development boards.
+
+---
+
+Rule `Espressif-devportal.TermsAcronyms`
+
+LP-Core integrates an IMAC CPU.
+
+---
+
+Rules `Espressif-devportal.TermsFixedPattern` and `Espressif-devportal.TermsSingleCorrectSpelling`
+
+Espressif SOCs are famous for its Wi-Fi and bluetooth features. ESP-iDF programming guide is also popular.
+
+---
+
+Rule `Espressif-devportal.UsefulLinkText`
+
+For details, see [here](https://google.com) and [on this page][example].
+
+[example]: https://google.com


### PR DESCRIPTION
## Description

This PR adds a Vale configuration and Espressif rules to lint the content in English.

The results of some checks can be seen in the `Files` tab > `README.md`.

In issue `.vale/styles/Espressif-devportal.TermsFixedPattern`, we need to agree on how to refer to Espressif / ESP / ESP32 chips or devices or products...

## Related

- The rule `.vale/styles/Espressif-devportal.UsefulLinkText` fixes the issue #169 

## Testing

Testing has been done in testing environments [1](https://github.com/f-hollow/developer-portal/pull/10) and [2](https://github.com/f-hollow/developer-portal/pull/11).

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
