### PR TITLE
Sync Merge: ci/sync_merge_gitlab_to_github

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,54 @@
+default:
+  interruptible: true
+
+.comment_template:
+  image: badouralix/curl-jq
+  tags:
+    - deploy_docs
+    - shiny
+
+.add_comment_script: &add_comment_script
+  - |
+    GITLAB_API="https://${CI_SERVER_HOST}:${CI_SERVER_PORT}/api/v4/projects/${PROJECT_ID}/merge_requests/${MR_ID}/notes"
+    AUTH_HEADER="PRIVATE-TOKEN: ${GITLAB_BOT_API_TOKEN}"
+
+    # Get existing comments
+    API_RESPONSE=$(curl --silent --header "$AUTH_HEADER" "$GITLAB_API")
+
+    # Check if the response contains the expected structure
+    COMMENTS=$(echo "$API_RESPONSE" | jq -r ".[] | select(.body | contains(\"$COMMENT_IDENTIFIER\")) | .id")
+
+    # Delete previous preview comments
+    if [ -n "$COMMENTS" ]; then
+      for COMMENT_ID in $COMMENTS; do
+        curl --silent --request DELETE \
+          --header "$AUTH_HEADER" \
+          "${GITLAB_API}/${COMMENT_ID}"
+      done
+    fi
+
+    # Post a new comment
+    curl --silent --request POST \
+      --header "$AUTH_HEADER" \
+      --header "Content-Type: application/json" \
+      --data "{\"body\": \"$COMMENT_BODY\"}" \
+      "$GITLAB_API"
+
+# Define the reusable rule sets
+.default-rules:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+
+.label-based-rules:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_LABELS =~ /GitHub-Sync-Merge/ && $CI_MERGE_REQUEST_LABELS !~ /GitHub-Edit/'
+
 stages:
   - build
   - deploy
-  - comment
+  - comment_preview
+  - sync_merge
+  - comment_github_pr
 
 build_hugo:
   stage: build
@@ -9,7 +56,7 @@ build_hugo:
   tags:
     - build_docs
   rules:
-    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
+    !reference [.default-rules, rules]
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
     NAME: "${CI_COMMIT_REF_SLUG}"
@@ -30,7 +77,7 @@ deploy_preview_hugo:
     - deploy_docs
     - shiny
   rules:
-    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
+    !reference [.default-rules, rules]
   needs: ["build_hugo"]
   variables:
     SSH_KEY: "$DOCS_PREVIEW_PRIVATEKEY" # SSH_KEY used inside espressif/scp
@@ -50,13 +97,10 @@ deploy_preview_hugo:
     - echo "Preview ${SERVER_URL_BASE}/${NAME}"
 
 post_preview_link:
-  stage: comment
-  image: badouralix/curl-jq
-  tags:
-    - deploy_docs
-    - shiny
+  extends: .comment_template
+  stage: comment_preview
   rules:
-    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
+    !reference [.default-rules, rules]
   needs: ["deploy_preview_hugo"]
   variables:
     SERVER_URL_BASE: "$DOCS_PREVIEW_URL_BASE"
@@ -65,31 +109,123 @@ post_preview_link:
     PROJECT_ID: "$CI_MERGE_REQUEST_PROJECT_ID"
   script:
     - |
-      # Print MR_ID and PROJECT_ID for debugging
-      echo "MR_ID: ${MR_ID}"
-      echo "PROJECT_ID: ${PROJECT_ID}"
-      echo "$CI_SERVER_HOST"
-      echo "${CI_SERVER_PORT}"
+      # Create varialbes for adding a comment
+      export COMMENT_IDENTIFIER="🎉 Preview for this MR"
+      export PREVIEW_LINK="${SERVER_URL_BASE}/${NAME}"
+      export COMMENT_BODY="🎉 Preview for this MR: ${PREVIEW_LINK}"
 
-      GITLAB_API="https://${CI_SERVER_HOST}:${CI_SERVER_PORT}/api/v4/projects/${PROJECT_ID}/merge_requests/${MR_ID}/notes"
-      AUTH_HEADER="PRIVATE-TOKEN: ${GITLAB_BOT_API_TOKEN}"
+    - *add_comment_script
 
-      # Get existing comments
-      API_RESPONSE=$(curl --silent --header "$AUTH_HEADER" "$GITLAB_API")
-      echo "API Response: $API_RESPONSE"  # Add this line for debugging
+sync_merge_to_github:
+  stage: sync_merge
+  image: alpine:latest
+  tags:
+    - deploy_docs
+    - shiny
+  rules:
+    !reference [.label-based-rules, rules]
+  variables:
+    GITHUB_REPO: "espressif/developer-portal"
+  script:
+    - apk update # Update the package index
+    - apk add --no-cache git bash github-cli # Install github-cli
 
-      # Check if the response contains the expected structure
-      COMMENTS=$(echo "$API_RESPONSE" | jq -r '.[] | select(.body | contains("🎉 Preview for this MR")) | .id')
+    - export SOURCE_BRANCH="${CI_MERGE_REQUEST_SOURCE_BRANCH_NAME}"
 
-      # Delete previous preview comments
-      if [ -n "$COMMENTS" ]; then
-        for COMMENT_ID in $COMMENTS; do
-          curl --silent --request DELETE --header "$AUTH_HEADER" "${GITLAB_API}/${COMMENT_ID}"
-        done
+    # Configure Git
+    - git config --global user.email "developer.portal.bot@example.com"
+    - git config --global user.name "Developer-Portal-BOT"
+
+    # Clone the repository
+    - git clone "$CI_REPOSITORY_URL" repo || (echo "Error cloning repository" && exit 1)
+    - cd repo
+    # Rebase the feature branch on main
+    - git checkout "$SOURCE_BRANCH"
+    - git fetch origin main
+    - git rebase main
+    # Add GitHub remote and push the rebased branch to GitHub
+    - git remote add github "https://oauth2:${GITHUB_ACCESS_TOKEN}@github.com/${GITHUB_REPO}.git"
+    # Consider using --force-with-lease here
+    - git push -u -f github "$SOURCE_BRANCH"
+
+    # Wait for GitHub to register the branch
+    - sleep 5
+
+    # Create a PR on GitHub
+    - export GITHUB_TOKEN="$GITHUB_ACCESS_TOKEN"
+    - |
+      PR_URL=$(gh pr list \
+              --repo "$GITHUB_REPO" \
+              --head "$SOURCE_BRANCH" \
+              --json url \
+              --jq '.[].url')
+
+      if [[ -n "$PR_URL" ]]; then
+        PR_NUMBER=$(gh pr view "$PR_URL" --json number -q '.number')
+        echo "PR already exists: #$PR_NUMBER"
+        echo "**GitHub PR:** $PR_URL"
+      else
+        echo "No PR found. Creating a new one..."
+        gh pr create \
+          --repo "$GITHUB_REPO" \
+          --head "$SOURCE_BRANCH" \
+          --base main \
+          --title "Sync Merge: ${SOURCE_BRANCH}" \
+          --body $'This PR syncs the GitLab branch `'"${SOURCE_BRANCH}"$'` to GitHub.\n\nThe changes have been reviewed internally.\n\n> [!WARNING]\n>If, for any reason, changes need be committed directly to the GitHub PR (bypassing GitLab), add the label \`GitHub-Edit\` in the GitLab MR. This will disable GitLab CI sync-merge to prevent overwriting changes on GitHub.' \
+          --label "GitLab-Sync-Merge"
+
+        PR_URL=$(gh pr list \
+                --repo "$GITHUB_REPO" \
+                --head "$SOURCE_BRANCH" \
+                --json url \
+                --jq '.[].url')
+
+        if [[ -n "$PR_URL" ]]; then
+          PR_NUMBER=$(gh pr view "$PR_URL" --json number -q '.number')
+          echo "PR created successfully: #$PR_NUMBER"
+          echo "**GitHub PR:** $PR_URL"
+        else
+          echo "Failed to create PR."
+          exit 1
+        fi
       fi
 
-      # Post new preview link
-      PREVIEW_LINK="${SERVER_URL_BASE}/${NAME}"
-      COMMENT_BODY="🎉 Preview for this MR: ${PREVIEW_LINK}"
-      curl --silent --request POST --header "$AUTH_HEADER" --header "Content-Type: application/json" \
-        --data "{\"body\": \"${COMMENT_BODY}\"}" "$GITLAB_API"
+    # Store PR_NUMBER and PR_URL as artifacts
+    - cd $CI_PROJECT_DIR
+    - echo "PR_NUMBER=$PR_NUMBER" > pr_info.txt
+    - echo "PR_URL=$PR_URL" >> pr_info.txt
+
+  artifacts:
+    paths:
+      - pr_info.txt
+    expire_in: 1 hour
+
+sync_merge_comment:
+  extends: .comment_template
+  stage: comment_github_pr
+  rules:
+    !reference [.label-based-rules, rules]
+  needs:
+    - sync_merge_to_github
+  variables:
+    SERVER_URL_BASE: "$DOCS_PREVIEW_URL_BASE"
+    NAME: "${CI_COMMIT_REF_SLUG}"
+    MR_ID: "$CI_MERGE_REQUEST_IID"
+    PROJECT_ID: "$CI_MERGE_REQUEST_PROJECT_ID"
+  script:
+    - |
+      # Load PR_NUMBER and PR_URL from artifact file
+      if [ -f "pr_info.txt" ]; then
+        source pr_info.txt
+      else
+        echo "pr_info.txt not found!"
+        exit 1
+      fi
+
+      # Create varialbes for adding a comment
+      COMMENT_IDENTIFIER="🚀 GitHub PR"
+      COMMENT_BODY="🚀 GitHub PR for sync-merging: [#$PR_NUMBER]($PR_URL).\\n\\n\
+      > ⚠️ **Warning**\\n> \\n\
+      > If, for any reason, changes need be committed directly to the GitHub PR (bypassing GitLab), add the label \`GitHub-Edit\` in the GitLab MR. This will disable GitLab CI sync-merge to prevent overwriting changes on GitHub."
+
+    - *add_comment_script


### PR DESCRIPTION
This PR syncs the GitLab branch `ci/sync_merge_gitlab_to_github` to GitHub.

The changes have been reviewed internally.

> [!WARNING]
>If, for any reason, changes need be committed directly to the GitHub PR (bypassing GitLab), add in GitLab MR the label `GitHub-Edit`. This will disable GitLab CI sync-merge to prevent overwriting changes on GitHub.