### PR TITLE
Ci/add articles in yyyy/mm folder

### DIFF
--- a/.github/workflows/pr-publishing-dates.yml
+++ b/.github/workflows/pr-publishing-dates.yml
@@ -1,0 +1,103 @@
+name: Check publishing dates
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'content/blog/**'
+
+env:
+  TARGET_REPO_URL: "https://github.com/espressif/developer-portal.git"
+  TARGET_BRANCH: "main"
+
+jobs:
+  check-publishing-dates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR contents
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get added folders and files
+        id: added-files
+        run: |
+          # Add target remote and fetch its branches
+          git remote add target "$TARGET_REPO_URL"
+          git fetch target "$TARGET_BRANCH"
+
+          mkdir -p temp
+
+          git diff --name-only --diff-filter=A origin/${{ github.base_ref }}...HEAD > temp/added-files.txt
+
+          echo "List of added files:"
+          cat temp/added-files.txt
+
+          while IFS= read -r line; do
+            if [[ "$line" =~ ^content/blog/.*/index.md$ ]]; then
+              echo "$line" >> temp/index.txt
+              dirname "$line" >> temp/folders.txt
+            fi
+          done < temp/added-files.txt
+
+      - name: Validate year and month folder
+        run: |
+          CURRENT_YEAR=$(date +%Y)
+          CURRENT_MONTH=$(date +%m)
+
+          while IFS= read -r folder; do
+            if [[ "$folder" =~ ^content/blog/([0-9]{4})/([0-9]{2})/ ]]; then
+              year="${BASH_REMATCH[1]}"
+              month="${BASH_REMATCH[2]}"
+              if [[ "$year" != "$CURRENT_YEAR" || "$month" != "$CURRENT_MONTH" ]]; then
+                echo "$folder" >> temp/incorrect-yyyy-mm.txt
+              fi
+            else
+              echo "$folder" >> temp/no-yyyy-mm.txt
+            fi
+          done < temp/folders.txt
+
+      - name: Make sure folders are under current YYYY/MM
+        run: |
+          error_found=0
+
+          CURRENT_YEAR=$(date +%Y)
+          CURRENT_MONTH=$(date +%m)
+
+          if [[ -s temp/no-yyyy-mm.txt ]]; then
+            echo "Move your article folder(s) to 'content/blog/${CURRENT_YEAR}/${CURRENT_MONTH}/':"
+            cat temp/no-yyyy-mm.txt
+            error_found=1
+          fi
+
+          if [[ -s temp/incorrect-yyyy-mm.txt ]]; then
+            echo "Move your article folder(s) to 'content/blog/${CURRENT_YEAR}/${CURRENT_MONTH}/':"
+            cat temp/incorrect-yyyy-mm.txt
+            error_found=1
+          fi
+
+          exit $error_found
+
+      - name: Check index.md dates
+        if: always()
+        run: |
+          error_found=0
+
+          today=$(date +%Y-%m-%d)
+
+          while IFS= read -r mdfile; do
+            if [[ -f "$mdfile" ]]; then
+              post_date=$(awk '/^date:/ {gsub(/["'\''"]/,"",$2); print $2}' "$mdfile")
+
+              if [[ ! "$post_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+                echo "In '$mdfile' YAML header, make sure the date is in YYYY-MM-DD format."
+                error_found=1
+              elif [[ "$post_date" != "$today" ]]; then
+                echo "In '$mdfile' YAML header, make sure the date is today: $today."
+                error_found=1
+              fi
+            fi
+          done < temp/index.txt
+
+          exit $error_found

--- a/.github/workflows/pr-publishing-dates.yml
+++ b/.github/workflows/pr-publishing-dates.yml
@@ -93,8 +93,8 @@ jobs:
               if [[ ! "$post_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
                 echo "In '$mdfile' YAML header, make sure the date is in YYYY-MM-DD format."
                 error_found=1
-              elif [[ "$post_date" != "$today" ]]; then
-                echo "In '$mdfile' YAML header, make sure the date is today: $today."
+              elif [[ "$post_date" < "$today" ]]; then
+                echo "Once your article in '$mdfile' is approved, make sure the date in its YAML header is not in the past (found: $post_date, today: $today)."
                 error_found=1
               fi
             fi

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,4 +1,4 @@
 ---
 title: "{{ replace .Name "-" " " | title }}"
-date: {{ .Date }}
+date: "{{ now.Format "2006-01-02" }}"
 ---

--- a/content/pages/contribution-guide/writing-content/index.md
+++ b/content/pages/contribution-guide/writing-content/index.md
@@ -24,11 +24,14 @@ See also the official [docs](https://gohugo.io/getting-started/quick-start/#add-
 
 - To create a new article, determine the path and run
   ```sh
-  hugo new content <path/index.md>
-  # Example
-  hugo new content blog/contribution-guide/index.md
+  # Blog article
+  hugo new content blog/YYYY/MM/<article-folder-name>/index.md
+  # Blog article example
+  hugo new content blog/2025/04/ulp-lp-core-get-started/index.md
+  # Non-blog articles (workshops, events etc.)
+  hugo new content <path>/index.md
   ```
-  This assumes that you want to organize the content as a leaf bundle (the usual way). You can also use the [branch bundle](https://gohugo.io/content-management/page-bundles/#comparison).
+  This assumes that you want to organize the content as a leaf bundle (a single article). For multi-article entries (workshops, etc.), use the [branch bundle](https://gohugo.io/content-management/page-bundles/#comparison).
 - To view the changes, in your project folder run
   ```sh
   hugo server


### PR DESCRIPTION
## Description

This PR updates the following:

- When creating an article using the `hugo new content` command, it won't add a timezone and will default to midnight (UTC+0).
- In the contribution guide instructions, added `YYYY/MM` to `hugo new content` example.
- Implemented CI checks:
  - Articles added in `content/blog/` need to be in the current `content/blog/YYYY/MM/` folder
  - Articles need to bear today's date without a timezone

> [!NOTE]
> The commit `test: add articles with issues in dates` is for demo purposes only. It will be removed before merging.

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

The workflow has been thoroughly tested in this PR.


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
