### PR TITLE
Sync Merge: feat/add_bilibili_links

### DIFF
--- a/content/blog/2025/03/nuttx-python-esp32s3/index.md
+++ b/content/blog/2025/03/nuttx-python-esp32s3/index.md
@@ -265,6 +265,8 @@ nsh> cat /proc/cpuload
 The following video shows this demo: the RGB LED goes from green to red when the CPU load average goes from 0% to 100%.
 
 {{< youtube EpDpqbnYJyo >}}
+{{< bilibili-note BV1PWEXzpE9s >}}
+
 
 ## Conclusion
 

--- a/content/blog/2025/05/nuttx-motor-control-and-sensing/index.md
+++ b/content/blog/2025/05/nuttx-motor-control-and-sensing/index.md
@@ -488,7 +488,9 @@ Command: 77.46%, Speed: 125.13 RPM
 Command: 82.50%, Speed: 133.16 RPM
 ```
 
-{{<youtube jeZbwqXmgmY >}}
+{{< youtube jeZbwqXmgmY >}}
+{{< bilibili-note BV1uXEXzYEZy >}}
+
 
 ## Conclusion
 

--- a/layouts/shortcodes/bilibili-note.html
+++ b/layouts/shortcodes/bilibili-note.html
@@ -1,0 +1,4 @@
+{{ $id := .Get 0 }}
+<p style="margin-top: 0.1em; margin-bottom: -1.5em; font-size: 0.9em; color: gray; text-align: right; margin-right: 0.3em;">
+(Also available on <a href="https://www.bilibili.com/video/{{ $id }}" target="_blank" rel="noopener">BiliBili</a>)
+</p>


### PR DESCRIPTION
This PR syncs the GitLab branch `feat/add_bilibili_links` to GitHub.

This MR adds the following:

- The `bilibili-note` shortcode to include a note with a BiliBili link under a YouTube video.
- Links to two BiliBili videos in the articles below (after clicking a link, scroll down a bit):
  - [Running Python on ESP32-S3 with NuttX](https://developer.espressif.com/blog/2025/03/nuttx-python-esp32s3/)
  - [NuttX for Motor Control and Sensing: MCPWM and DC Motor Control](https://developer.espressif.com/blog/2025/05/nuttx-motor-control-and-sensing/)

The changes have been reviewed internally.

> [!WARNING]
>If, for any reason, changes need be committed directly to the GitHub PR (bypassing GitLab), add the label \`GitHub-Edit\` in the GitLab MR. This will disable GitLab CI sync-merge to prevent overwriting changes on GitHub.