### PR TITLE
Ci/improve article details workflow

### DIFF
--- a/.github/workflows/pr-article-details.yml
+++ b/.github/workflows/pr-article-details.yml
@@ -59,12 +59,13 @@ jobs:
               FOLDER_YM="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
             fi
 
-            ARTICLE_DATE=$(awk -F': "' '/^date: "/ {gsub(/"/, "", $2); print $2}' "$index_file")
+            ARTICLE_DATE=$(awk '/^date:/ { gsub(/["'\'']/, "", $2); print $2 }' "$index_file")
             [[ -z "$ARTICLE_DATE" ]] && { echo "No valid date in $index_file"; continue; }
 
             ARTICLE_YM="${ARTICLE_DATE:0:7}"
 
-            ARTICLE_SUMMARY_RAW=$(awk -F': "' '/^summary: "/ {gsub(/"/, "", $2); print $2; exit}' "$index_file")
+            ARTICLE_SUMMARY_RAW=$(awk '/^summary:/ { $1=""; gsub(/^[: \t'\''"]+|["'\'' \t]+$/, "", $0); print; exit }' "$index_file")
+
             # If summary is empty or not found, set to empty string
             ARTICLE_SUMMARY_RAW=${ARTICLE_SUMMARY_RAW:-""}
             # Extract up to first 5 words if ARTICLE_SUMMARY_RAW is not empty

--- a/.gitlab/ci/check_article_details.yml
+++ b/.gitlab/ci/check_article_details.yml
@@ -55,12 +55,12 @@ check_article_details:
           FOLDER_YM="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
         fi
 
-        ARTICLE_DATE=$(awk -F': "' '/^date: "/ {gsub(/"/, "", $2); print $2}' "$index_file")
+        ARTICLE_DATE=$(awk '/^date:/ { gsub(/["'\'']/, "", $2); print $2 }' "$index_file")
         [[ -z "$ARTICLE_DATE" ]] && { echo "No valid date in $index_file"; continue; }
 
         ARTICLE_YM="${ARTICLE_DATE:0:7}"
 
-        ARTICLE_SUMMARY_RAW=$(awk -F': "' '/^summary: "/ {gsub(/"/, "", $2); print $2; exit}' "$index_file")
+        ARTICLE_SUMMARY_RAW=$(awk '/^summary:/ { $1=""; gsub(/^[: \t'\''"]+|["'\'' \t]+$/, "", $0); print; exit }' "$index_file")
         ARTICLE_SUMMARY_RAW=${ARTICLE_SUMMARY_RAW:-""}
 
         if [[ -n "$ARTICLE_SUMMARY_RAW" ]]; then


### PR DESCRIPTION
## Description

This PR improves the `check-article-details` workflow added in #493.

**Before this PR**: the workflow worked correctly only if the `date` or `summary` values in article headers were wrapped in double-quotes.

**Now**: The `date` or `summary` values can be wrapped in no quotes, single-quotes, or double-quotes.

## Related

- PR #493 

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

- GitHub CI -- see PR [#18](https://github.com/f-hollow/developer-portal/pull/18)

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
