### PR TITLE
Update versions of Hugo and blowfish

### DIFF
--- a/.github/workflows/cron-deploy-hugo-site.yml
+++ b/.github/workflows/cron-deploy-hugo-site.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install Hugo CLI
         env:
-          HUGO_VERSION: 0.135.0
+          HUGO_VERSION: 0.147.5
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install Hugo CLI
         env:
-          HUGO_VERSION: 0.135.0
+          HUGO_VERSION: 0.147.5
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb

--- a/.github/workflows/pr-build-preview.yml
+++ b/.github/workflows/pr-build-preview.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Install Hugo CLI
         env:
-          HUGO_VERSION: 0.135.0
+          HUGO_VERSION: 0.147.5
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb

--- a/.gitlab/ci/build_hugo.yml
+++ b/.gitlab/ci/build_hugo.yml
@@ -1,6 +1,6 @@
 build_hugo:
   stage: build_hugo
-  image: "${CI_TEMPLATE_REGISTRY_HOST}/pages/hugo/hugo_extended:0.135.0"
+  image: "hugomods/hugo:debian-base-0.147.5"
   tags:
     - build_docs
   rules:

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,11 +5,11 @@
   {{ if .Params.showHero | default (.Site.Params.article.showHero | default false) }}
   {{ $heroStyle := .Params.heroStyle }}
   {{ if not $heroStyle }}{{ $heroStyle = .Site.Params.article.heroStyle }}{{ end }}
-  {{ $heroStyle := print "partials/hero/" $heroStyle ".html" }}
-  {{ if templates.Exists $heroStyle }}
+  {{ $heroStyle := print "hero/" $heroStyle ".html" }}
+  {{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
   {{ partial $heroStyle . }}
   {{ else }}
-  {{ partial "partials/hero/basic.html" . }}
+  {{ partial "hero/basic.html" . }}
   {{ end }}
   {{ end }}
 

--- a/layouts/partials/hugo-embedded/shortcodes/figure-default.html
+++ b/layouts/partials/hugo-embedded/shortcodes/figure-default.html
@@ -1,0 +1,43 @@
+{{/*
+  Copied from Hugo v0.146
+  Source: https://github.com/gohugoio/hugo/blob/83cfdd78ca6469e6d7265323d9fad1448880e559/tpl/tplimpl/embedded/templates/_shortcodes/figure.html
+*/}}
+
+<figure{{ with .Get "class" }} class="{{ . }}"{{ end }}>
+  {{- if .Get "link" -}}
+    <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
+  {{- end -}}
+
+  {{- $u := urls.Parse (.Get "src") -}}
+  {{- $src := $u.String -}}
+  {{- if not $u.IsAbs -}}
+    {{- with or (.Page.Resources.Get $u.Path) (resources.Get $u.Path) -}}
+      {{- $src = .RelPermalink -}}
+    {{- end -}}
+  {{- end -}}
+
+  <img src="{{ $src }}"
+    {{- if or (.Get "alt") (.Get "caption") }}
+    alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify| plainify }}{{ end }}"
+    {{- end -}}
+    {{- with .Get "width" }} width="{{ . }}"{{ end -}}
+    {{- with .Get "height" }} height="{{ . }}"{{ end -}}
+    {{- with .Get "loading" }} loading="{{ . }}"{{ end -}}
+  ><!-- Closing img tag -->
+  {{- if .Get "link" }}</a>{{ end -}}
+  {{- if or (or (.Get "title") (.Get "caption")) (.Get "attr") -}}
+    <figcaption>
+      {{ with (.Get "title") -}}
+        <h4>{{ . }}</h4>
+      {{- end -}}
+      {{- if or (.Get "caption") (.Get "attr") -}}<p>
+        {{- .Get "caption" | markdownify -}}
+        {{- with .Get "attrlink" }}
+          <a href="{{ . }}">
+        {{- end -}}
+        {{- .Get "attr" | markdownify -}}
+        {{- if .Get "attrlink" }}</a>{{ end }}</p>
+      {{- end }}
+    </figcaption>
+  {{- end }}
+</figure>

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -1,0 +1,51 @@
+{{ $disableImageOptimization := .Site.Params.disableImageOptimization | default false }}
+{{ if .Get "default" }}
+  {{ partial "hugo-embedded/shortcodes/figure-default.html" . }}
+{{ else }}
+  {{- $url := urls.Parse (.Get "src") }}
+  {{- $altText := .Get "alt" }}
+  {{- $caption := .Get "caption" }}
+  {{- $href := .Get "href" }}
+  {{- $class := .Get "class" }}
+  {{- $target := .Get "target" | default "_blank" }}
+  {{- $nozoom := .Get "nozoom" | default false -}}
+
+  <figure>
+  {{- with $href }}<a href="{{ . }}" {{ with $target }}target="{{ . }}"{{ end }}>{{ end -}}
+  {{- if findRE "^https?" $url.Scheme }}
+      <img class="my-0 rounded-md{{ with $nozoom }} nozoom{{ end }}{{ with $class }} {{ . }}{{ end }}" src="{{ $url.String }}" alt="{{ $altText }}" />
+  {{- else }}
+    {{- $resource := "" }}
+    {{- if $.Page.Resources.GetMatch ($url.String) }}
+      {{- $resource = $.Page.Resources.GetMatch ($url.String) }}
+    {{- else if resources.GetMatch ($url.String) }}
+      {{- $resource = resources.Get ($url.String) }}
+    {{- end }}
+    {{- with $resource }}
+      {{- if or $disableImageOptimization (eq .MediaType.SubType "svg")}}
+        <img
+          class="my-0 rounded-md{{ with $nozoom }} nozoom{{ end }}{{ with $class }} {{ . }}{{ end }}"
+          src="{{ .RelPermalink }}"
+          alt="{{ $altText }}"
+        />
+      {{- else }}
+        <img
+          class="my-0 rounded-md{{ with $nozoom }} nozoom{{ end }}{{ with $class }} {{ . }}{{ end }}"
+          srcset="
+          {{ (.Resize "330x").RelPermalink }} 330w,
+          {{ (.Resize "660x").RelPermalink }} 660w,
+          {{ (.Resize "1024x").RelPermalink }} 1024w,
+          {{ (.Resize "1320x").RelPermalink }} 2x"
+          src="{{ (.Resize "660x").RelPermalink }}"
+          data-zoom-src="{{ (.Resize "1320x").RelPermalink }}"
+          alt="{{ $altText }}"
+        />
+      {{- end }}
+    {{- else }}
+      <img class="my-0 rounded-md{{ with $nozoom }} nozoom{{ end }}{{ with $class }} {{ . }}{{ end }}" src="{{ $url.String }}" alt="{{ $altText }}" />
+    {{- end }}
+  {{- end }}
+  {{ with $caption }}<figcaption>{{ . | markdownify }}</figcaption>{{ end }}
+  {{ if $href }}</a>{{ end }}
+  </figure>
+{{- end -}}


### PR DESCRIPTION
## Description

This PR updates the versions of the software:

- [Hugo](https://github.com/gohugoio/hugo) from `0.135.0` to `0.147.5` (latest supported by Blowfish v2.86.0)
- [Blowfish theme](https://github.com/nunocoracao/blowfish)
  - Fast-forwarded from
    - Commit ID: `f037da312028f628e59eee7ef063dfc4edd3d78c`
    - Timestamp: `Fri Oct 4 16:01:50 2024 +0100`
  - Fast-forwarded to
    - Version: `v2.86.0`
    - Commit ID: `0b06a64139beba6287e7685f4c810ad4ff772fde`
    - Timestamp: `Tue May 27 01:03:33 2025 +0100`

As of now, our project has issues with the `figure` shortcode. Upstream PR [#2210](https://github.com/nunocoracao/blowfish/pull/2210/) has been submitted. As our project needs a fix now, this MR has the following changes:

- Software updated according to the notes above
- Blowfish `figure` shortcode temporarily updated according to the changes in the upstream PR #2210 (once merged, the Blowfish submodule will be fast-forwarded and this commit revoked)
- Added upstream changes to the overridden by us `single.html`

## Related


## Testing

Testing has been done locally and is being done in this PR.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
