### PR TITLE
Sync Merge: ci/check_article_details_no_added_files

### DIFF
--- a/.github/workflows/pr-article-details.yml
+++ b/.github/workflows/pr-article-details.yml
@@ -31,6 +31,11 @@ jobs:
 
           git diff --name-only --diff-filter=A origin/${{ github.base_ref }}...HEAD > temp/added-files.txt
 
+          if [ ! -s temp/added-files.txt ]; then
+            echo "✅ No files added. Nothing to check."
+            exit 0
+          fi
+
           echo "List of added files:"
           cat temp/added-files.txt
 
@@ -40,10 +45,16 @@ jobs:
             fi
           done < temp/added-files.txt
 
+          if [ ! -s temp/index-files.txt ]; then
+            echo "✅ No index.md files added. Nothing to validate."
+            exit 0
+          fi
+
           echo "List of added index files:"
           cat temp/index-files.txt
 
       - name: Extract article details
+        if: success() && hashFiles('temp/index-files.txt') != ''
         run: |
           extracted_article_data="[]"
 
@@ -111,6 +122,7 @@ jobs:
           cat temp/extracted_article_data.json
 
       - name: Validate article details
+        if: success() && hashFiles('temp/index-files.txt') != ''
         run: |
           job_error=0
           extracted_article_data="temp/extracted_article_data.json"

--- a/.gitlab/ci/check_article_details.yml
+++ b/.gitlab/ci/check_article_details.yml
@@ -26,6 +26,11 @@ check_article_details:
 
       git diff --name-only --diff-filter=A target/${TARGET_BRANCH}...HEAD > temp/added-files.txt
 
+      if [ ! -s temp/added-files.txt ]; then
+        echo "✅ No files added. Nothing to check."
+        exit 0 # Exit early and succeed
+      fi
+
       echo "List of added files:"
       cat temp/added-files.txt
 
@@ -36,7 +41,7 @@ check_article_details:
       done < temp/added-files.txt
 
       if [ ! -s temp/index-files.txt ]; then
-        echo "No index files added -- skipping job."
+        echo "✅ No index.md files added. Nothing to validate."
         exit 0  # Exit early and succeed
       fi
 


### PR DESCRIPTION
This PR syncs the GitLab branch `ci/check_article_details_no_added_files` to GitHub.

The changes have been reviewed internally.

> [!WARNING]
>If, for any reason, changes need be committed directly to the GitHub PR (bypassing GitLab), add the label \`GitHub-Edit\` in the GitLab MR. This will disable GitLab CI sync-merge to prevent overwriting changes on GitHub.