### PR TITLE
fix: update relative links in assignments and lectures for consistency

### DIFF
--- a/content/workshops/esp-idf-basic/assignment-1-1/index.md
+++ b/content/workshops/esp-idf-basic/assignment-1-1/index.md
@@ -129,4 +129,4 @@ Identify the output string and change it to `Hello LED`.
 You can now create a new project and flash it on the board. In the next assignment, we'll consolidate this process.
 
 ### Next step
-> Next assignment &rarr; [Assignment 1.2](assignment-1-2/)
+> Next assignment &rarr; [Assignment 1.2](../assignment-1-2/)

--- a/content/workshops/esp-idf-basic/assignment-1-2/index.md
+++ b/content/workshops/esp-idf-basic/assignment-1-2/index.md
@@ -38,4 +38,4 @@ In the next lesson, we will focus on what usually is the main topic for an Espre
 
 ### Next step
 
-> Next lecture &rarr; __[Lecture 2](lecture-2/)__
+> Next lecture &rarr; __[Lecture 2](../lecture-2/)__

--- a/content/workshops/esp-idf-basic/assignment-2-1/index.md
+++ b/content/workshops/esp-idf-basic/assignment-2-1/index.md
@@ -454,4 +454,4 @@ Now you can put the Espressif device into Soft-AP or STA mode and create an HTTP
 
 ### Next step
 
-> Next assignment: [Assignment 2.2](assignment-2-2/)
+> Next assignment: [Assignment 2.2](../assignment-2-2/)

--- a/content/workshops/esp-idf-basic/assignment-2-2/index.md
+++ b/content/workshops/esp-idf-basic/assignment-2-2/index.md
@@ -228,8 +228,8 @@ Now we have a clear picture of how to connect REST API requests to physical devi
 
 If you still have time, you can try this optional assignment.
 
-> Next (optional) assignment &rarr; [Assignment 2.3](assignment-2-3/)
+> Next (optional) assignment &rarr; [Assignment 2.3](../assignment-2-3/)
 
 Otherwise, you can move to the third lecture.
 
-> Next lecture &rarr; [Lecture 3](lecture-3/)
+> Next lecture &rarr; [Lecture 3](../lecture-3/)

--- a/content/workshops/esp-idf-basic/assignment-2-3/index.md
+++ b/content/workshops/esp-idf-basic/assignment-2-3/index.md
@@ -34,4 +34,4 @@ OFF: off_time[2]
 If you managed to reach this point, it means you have good understanding of a basic REST API implementation. You can now move to the third lecture, detailing the management of external libraries and the use of the components found on the component registry.
 
 ### Next step
-> Next lecture &rarr; [Lecture 3](lecture-3/)
+> Next lecture &rarr; [Lecture 3](../lecture-3/)

--- a/content/workshops/esp-idf-basic/assignment-3-1/index.md
+++ b/content/workshops/esp-idf-basic/assignment-3-1/index.md
@@ -112,4 +112,4 @@ Now you are ready to:
 You can now create your own components, which makes your code easier to maintain and to share. In the next assignment, you will face a typical development problem and use the skills you just learned.
 
 ### Next step
-> Next assignment &rarr; [Assignment 3.2](assignment-3-2/)
+> Next assignment &rarr; [Assignment 3.2](../assignment-3-2/)

--- a/content/workshops/esp-idf-basic/assignment-3-2/index.md
+++ b/content/workshops/esp-idf-basic/assignment-3-2/index.md
@@ -23,4 +23,4 @@ Now that you can read the on board sensor, you're ready to move to the last assi
 
 ### Next step
 
-> Next assignment &rarr; [Assignment 3.3](assignment-3-3/)
+> Next assignment &rarr; [Assignment 3.3](../assignment-3-3/)

--- a/content/workshops/esp-idf-basic/assignment-3-3/index.md
+++ b/content/workshops/esp-idf-basic/assignment-3-3/index.md
@@ -36,4 +36,4 @@ You have create a basic IoT application, putting together sensor reading and HTT
 
 ### Next step
 
-> Next step &rarr; [Conclusion](#conclusion)
+> Next step &rarr; [Conclusion](../#conclusion)

--- a/content/workshops/esp-idf-basic/lecture-1/index.md
+++ b/content/workshops/esp-idf-basic/lecture-1/index.md
@@ -264,4 +264,4 @@ You can find the board schematic on the [KiCad Libraries GitHub Repository](http
 Now that we have a high-level overview of both hardware and firmware, we're ready to start the first assignment.
 
 ### Next Step
-> Next Assignment &rarr; __[assignment 1.1](assignment-1-1)__
+> Next Assignment &rarr; __[assignment 1.1](../assignment-1-1)__

--- a/content/workshops/esp-idf-basic/lecture-2/index.md
+++ b/content/workshops/esp-idf-basic/lecture-2/index.md
@@ -226,4 +226,4 @@ Now you have all the technical background to start the assignments.
 
 ### Next step
 
-> Next assignment &rarr; __[Assignment 2.1](assignment-2-1/)__
+> Next assignment &rarr; __[Assignment 2.1](../assignment-2-1/)__

--- a/content/workshops/esp-idf-basic/lecture-3/index.md
+++ b/content/workshops/esp-idf-basic/lecture-3/index.md
@@ -254,4 +254,4 @@ In this short lecture, we explored two main ways to include external libraries: 
 
 ### Next step
 
-> Next assignment &rarr; [Assignment 3.1](assignment-3-1/)
+> Next assignment &rarr; [Assignment 3.1](../assignment-3-1/)


### PR DESCRIPTION
## Description

This PR addresses an issue where relative links in various assignment and lecture files within the `esp-idf-basic` workshop were inconsistent. 

Specifically, this fixes the issue where the "next step" links for each "assignments and lectures" could not be opened.

## Related

https://developer.espressif.com/workshops/esp-idf-basic/