### PR TITLE
ci: chck changed files total size

### DIFF
--- a/tools/ci/check_repo_consistency.sh
+++ b/tools/ci/check_repo_consistency.sh
@@ -10,6 +10,7 @@ TARGET_REPO_URL="${TARGET_REPO_URL:-https://github.com/espressif/developer-porta
 TARGET_BRANCH="${TARGET_BRANCH:-main}"
 
 DYNAMIC_BLOCK_FILE="layouts/shortcodes/dynamic-block.html"
+MAX_CHANGED_FILES_SIZE_BYTES=$((500 * 1024))
 
 
 ###############################################################################
@@ -121,6 +122,50 @@ check_dynamic_block_localmode() {
   return 0
 }
 
+check_changed_files_total_size() {
+  local base_ref="$1"
+  local max_size_bytes="$2"
+
+  local changed_files
+  changed_files=$(git diff --name-only --diff-filter=AM "$base_ref"...HEAD)
+
+  if [ -z "$changed_files" ]; then
+    echo
+    echo "No added/modified files found for size check."
+    return 0
+  fi
+
+  local total_size=0
+  local file_size=0
+
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+
+    if git cat-file -e "HEAD:$file" 2>/dev/null; then
+      file_size=$(git cat-file -s "HEAD:$file")
+      total_size=$((total_size + file_size))
+    fi
+  done <<< "$changed_files"
+
+  # Ceiling division for KB display (round up partial kilobytes)
+  local total_kb limit_kb
+  total_kb=$(( (total_size + 1023) / 1024 ))
+  limit_kb=$(( (max_size_bytes + 1023) / 1024 ))
+
+  echo
+  echo "Total size of added/modified files: ${total_kb} KB (limit: ${limit_kb} KB)"
+
+  if [ "$total_size" -gt "$max_size_bytes" ]; then
+    echo
+    echo "❌ Committed files exceed 500 KB limit."
+    echo "   Please compress or remove unnecessary ones to keep the site lightweight."
+    return 1
+  fi
+
+  echo "Committed files are within 500 KB limit."
+  return 0
+}
+
 
 ###############################################################################
 # MAIN
@@ -142,6 +187,11 @@ check_forbidden_filetypes "$BASE_REF" || overall_error=1
 banner "🔎 Checking dynamic block localmode..."
 
 check_dynamic_block_localmode || overall_error=1
+
+
+banner "🔎 Checking changed files total size..."
+
+check_changed_files_total_size "$BASE_REF" "$MAX_CHANGED_FILES_SIZE_BYTES" || overall_error=1
 
 
 echo


### PR DESCRIPTION
<!--
⚠️ PRE-SUBMISSION REMINDERS
1. Read the project style guidelines (CONTRIBUTING.md).
2. For Work In Progress, please use the Draft PR feature.
3. Ensure you have tested locally with Hugo.
-->

## 📝 Description

<!--
- Summary of the article or changes being introduced.
- Context: Why is this change necessary? (e.g., New tutorial, fixing a typo, updating SDK version).
-->

On a couple of occasions, the files committed to the repo were unreasonably large.

This PR adds a check to make sure that the total size of committed files does not exceed 500 KB.

If certain content exceeds 500 KB for a good reason, we can still merge it, but this check will help us take an informed decision.

## Publish date

Expected publish date: `YYYY-MM-DD`

<!--
Please note the expected review time:
  - Announcements:  within 1 week
  - Simple articles:       1-2 weeks
  - Tutorial or workshops: 3-4 weeks
-->

## Review process

- [ ] Initiate **technical review**
    - [ ] This item is N/A
    - Add subject matter experts (your team members, experts in the field)
- [ ] Once tech review mostly done, initiate **editorial review**
    - Add technical editors (`@f-hollow`, `@FBEZ`, and/or `@pedrominatel`)

## Checks

- [ ] Article folder and file names:
    - Folder path is `content/blog/YYYY/MM/my-new-article` (articles only)
    - Folder and file names have no underscores, spaces, or uppercase letters (~~My new_article~~)
- [ ] New article's YAML frontmatter:
    - Title updated
    - Date matches the format `date: 20YY-MM-DD`
    - Summary updated
    - Authors added (see [Add youself as an author](https://developer.espressif.com/pages/contribution-guide/writing-content/#add-youself-as-an-author))
    - Tags added
- [ ] Updated article's YAML frontmatter:<br>
    - [ ] This item is N/A
    - If article folder is moved or renamed, the field `aliases:` with a new URL slug is added
    - Date of update is added `lastmode: 20YY-MM-DD`
- [ ] Article media files:
    - All images are in .WebP format (see [Use WebP for raster images](https://developer.espressif.com/pages/contribution-guide/writing-content/#use-webp-for-raster-images))
    - Images are compressed within 100-300 KB, with a hard limit of ≤ 500 kB
    - Where possible, Hugo shortcodes are used instead of raw HTML for content types unsupported by markdown (see [Use additional content types](https://developer.espressif.com/pages/contribution-guide/writing-content/#use-additional-content-types))
- [ ] Links in articles
    - Make sure all links are valid
    - No links to Google docs present
    - Use a specific ESP-IDF version in links (avoid `stable`, hard no for `latest`)
- [ ] Git history
    - Commits are clean and squashed to the minimum necessary
    - Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
    - Your feature branch is rebased on `main`

## 🔗 Related

<!--
- Fixes #ISSUENUMBER
- Related #PRNUMBER
- Links to related documentation
-->



## 🧪 Testing (Hugo)

<!--
Describe how you tested or verified your contribution. For example, you can say:

- [ ] I have run `hugo server` locally and verified there are no build errors.
- [ ] I have checked the rendered output on Desktop and Mobile view.
- [ ] I have verified that internal links and syntax highlighting work correctly.
-->
