### PR TITLE
ci: escape regex metacharacters in baseline links for .lycheeignore

### DIFF
--- a/.github/workflows/pr-check-links-worker.yml
+++ b/.github/workflows/pr-check-links-worker.yml
@@ -67,7 +67,10 @@ jobs:
         run: git switch -- "$HEAD_REF"
 
       - name: Append links-baseline.txt to .lycheeignore
-        run: cat links-baseline.txt >> .lycheeignore
+        # .lycheeignore lines are parsed as regexes; escape metacharacters so
+        # baseline URLs are treated literally (e.g. `?data={...}` in a URL is
+        # an invalid regex quantifier and aborts lychee with a parse error).
+        run: sed 's/[][\.^$*+?(){}|]/\\&/g' links-baseline.txt >> .lycheeignore
 
       - name: Dump names of files altered in PR and append hash sign to find links with anchors
         run: |


### PR DESCRIPTION
## Description

The `pr-check-links` workers append the baseline link dump verbatim to `.lycheeignore`, whose lines lychee parses as regexes. Any baseline URL containing regex metacharacters aborts the whole check with a parse error before a single link is verified.

This is live on `main` today: the provisioning QR-code URL in `content/blog/2026/05/simple-provisioning/` (`qrcode.html?data={%22ver%22...}`) contains `{...}`, which lychee rejects as an invalid repetition quantifier:

```
Error: regex parse error:
    https://espressif.github.io/esp-jumpstart/qrcode.html?data={%22ver%22,...}
error: repetition quantifier expects a valid decimal
```

As a result, every PR whose diff touches the `blog_0-9a-f` bucket currently fails `check-links` regardless of its own links (seen on #742, where `blog_0-9a-f` fails and `blog_g-z` passes).

The fix escapes regex metacharacters in the baseline dump before appending, so baseline URLs match literally.

## Related

- Observed on #742

## Testing

Verified the sed transform on the offending URL:

```
$ echo 'https://espressif.github.io/esp-jumpstart/qrcode.html?data={%22ver%22:%22v1%22}' | sed 's/[][\.^$*+?(){}|]/\\&/g'
https://espressif\.github\.io/esp-jumpstart/qrcode\.html\?data=\{%22ver%22:%22v1%22\}
```

which is a valid regex matching the URL literally.
