### PR TITLE
Fixed link to EIM

### DIFF
--- a/content/blog/2026/03/idf-v6-0-release/index.md
+++ b/content/blog/2026/03/idf-v6-0-release/index.md
@@ -101,7 +101,7 @@ For a full walkthrough including examples and migration tips, see the Developer 
 
 ESP-IDF 6.0 ships with a built-in **MCP (Model Context Protocol) server**, enabling AI assistants to interact directly with your ESP-IDF project through a standardized protocol. The server exposes tools for the most common development operations: building, flashing, setting the target, and cleaning, as well as resources to query the current project configuration, build status, and connected devices.
 
-The recommended way to launch the server is via `eim run`, which uses the [ESP-IDF Installation Manager (EIM)](https://github.com/espressif/idf-im-cli) to spawn a new process with the ESP-IDF environment already set up:
+The recommended way to launch the server is via `eim run`, which uses the [ESP-IDF Installation Manager (EIM)](https://github.com/espressif/idf-im-ui) to spawn a new process with the ESP-IDF environment already set up:
 
 ```bash
 eim run "idf.py mcp-server"

--- a/content/workshops/esp-idf-advanced/_index.md
+++ b/content/workshops/esp-idf-advanced/_index.md
@@ -58,7 +58,7 @@ To follow this workshop, make sure you meet the prerequisites listed below.
 * **VS Code** installed on your computer
 * **[ESP-IDF extension for VS Code](https://docs.espressif.com/projects/vscode-esp-idf-extension/en/latest/)** added to VS Code
 * **ESP-IDF** installed on your machine<br>
-  *It can be installed via VS Code or by using the [ESP-IDF Installation Manager](https://docs.espressif.com/projects/idf-im-cli/en/latest/index.html)*
+  *It can be installed via VS Code or by using the [ESP-IDF Installation Manager](https://docs.espressif.com/projects/idf-im-ui/en/latest/index.html)*
 
 ### Required Hardware
 

--- a/content/workshops/esp-idf-basic/_index.md
+++ b/content/workshops/esp-idf-basic/_index.md
@@ -64,7 +64,7 @@ To follow this workshop, make sure you meet the prerequisites listed below.
 * **VS Code** installed on your computer (v1.108+)
 * **[ESP-IDF extension for VS Code](https://docs.espressif.com/projects/vscode-esp-idf-extension/en/latest/)** added to VS Code (v1.11+)
 * **ESP-IDF** installed on your machine (__>v5.5,<6__)
-  *It can be installed via VS Code or by using the [ESP-IDF Installation Manager](https://docs.espressif.com/projects/idf-im-cli/en/latest/index.html)*
+  *It can be installed via VS Code or by using the [ESP-IDF Installation Manager](https://docs.espressif.com/projects/idf-im-ui/en/latest/index.html)*
 
 ### Required Hardware
 


### PR DESCRIPTION
simple fix of links to correct documentation and repository. The idf-im-cli repository was archived after the functionality of both was merged. The correct link to documentation is https://docs.espressif.com/projects/idf-im-ui/en/latest/