### PR TITLE
Docs/code block parameters

### DIFF
--- a/config/_default/markup.toml
+++ b/config/_default/markup.toml
@@ -7,6 +7,9 @@
 
 [highlight]
   noClasses = false
+  # Render `lineNos=true` as inline line numbers. The table layout Chroma
+  # produces leaves no gap between numbers and code.
+  lineNumbersInTable = false
 
 [tableOfContents]
   startLevel = 2

--- a/content/pages/contribution-guide/write-and-format-content/index.md
+++ b/content/pages/contribution-guide/write-and-format-content/index.md
@@ -269,26 +269,74 @@ After that, include your `.mp4` video using this shortcode:
 You might also find useful [Asciinema casts](#asciinema-casts) and [Video](#video).
 
 
-### Code block
+### Code blocks
 
-A code block can be inserted using the standard markdown syntax -- backticks.
+A code block can be inserted using the standard markdown syntax -- backticks. The Developer Portal supports additional parameters in fenced code blocks, including the ones from [highlight shortcode](https://gohugo.io/shortcodes/highlight/) and Blowfish's `title` parameter.
 
-Hugo also provides the [highlight shortcode](https://gohugo.io/shortcodes/highlight/) which offers additional features, such as numbering and highlighting lines:
+Here are the most useful additional parameters:
 
-{{< highlight c "linenos=table,hl_lines=3 5" >}}
-    led_strip_config_t strip_config = {
-        // Set the GPIO8 that the LED is connected
-        .strip_gpio_num = 8,
-        // Set the number of connected LEDs, 1
-        .max_leds = 1,
-        // Set the pixel format of your LED strip
-        .led_pixel_format = LED_PIXEL_FORMAT_GRB,
-        // LED model
-        .led_model = LED_MODEL_WS2812,
-        // In some cases, the logic is inverted
-        .flags.invert_out = false,
-    };
-{{< /highlight >}}
+| Parameter | Description |
+|--------|---------|
+| `title="string"` | Add a code block header (typically used for a code filename) |
+| `hl_lines="2 4-6"` | Highlight lines, e.g `"2 4-6"` or `[4,"7-9"]` |
+| `lineNos=true` | Add line numbers |
+| `lineNoStart="10"` | Start from given line number (default `1`) |
+| `anchorLineNos=true` | Make line numbers linkable anchors (also set `lineAnchors`) |
+| `lineAnchors="id"` | For each `anchorLineNos=true` code block, set ID to make links unique |
+
+Here is an example of a code block with a filename and highlighted lines:
+
+````markdown
+```c {title="main/blink_main.c" hl_lines="3"}
+void app_main(void)
+{
+    ESP_ERROR_CHECK(gpio_set_direction(BLINK_GPIO, GPIO_MODE_OUTPUT));
+    ESP_LOGI(TAG, "Blink LED configured on GPIO %d", BLINK_GPIO);
+}
+```
+````
+
+```c {title="main/blink_main.c" hl_lines="3"}
+void app_main(void)
+{
+    ESP_ERROR_CHECK(gpio_set_direction(BLINK_GPIO, GPIO_MODE_OUTPUT));
+    ESP_LOGI(TAG, "Blink LED configured on GPIO %d", BLINK_GPIO);
+}
+```
+
+Here is another example of a code block with line numbers that also have linkable anchors enabled:
+
+````markdown
+```c {lineNos=true anchorLineNos=true lineAnchors="led-strip"}
+led_strip_config_t strip_config = {
+  // Set the GPIO8 that the LED is connected
+  .strip_gpio_num = 8,
+  // Set the number of connected LEDs, 1
+  .max_leds = 1,
+  // Set the pixel format of your LED strip
+  .led_pixel_format = LED_PIXEL_FORMAT_GRB,
+  // LED model
+  .led_model = LED_MODEL_WS2812,
+  // In some cases, the logic is inverted
+  .flags.invert_out = false,
+};
+```
+````
+
+```c {lineNos=true anchorLineNos=true lineAnchors="led-strip"}
+led_strip_config_t strip_config = {
+  // Set the GPIO8 that the LED is connected
+  .strip_gpio_num = 8,
+  // Set the number of connected LEDs, 1
+  .max_leds = 1,
+  // Set the pixel format of your LED strip
+  .led_pixel_format = LED_PIXEL_FORMAT_GRB,
+  // LED model
+  .led_model = LED_MODEL_WS2812,
+  // In some cases, the logic is inverted
+  .flags.invert_out = false,
+};
+```
 
 
 ### Tabs

--- a/content/workshops/espressif-ide/index.md
+++ b/content/workshops/espressif-ide/index.md
@@ -263,7 +263,7 @@ This file will be used by this project when calling the SDK configuration interf
 
 To use the new configuration entries, you can do:
 
-{{< highlight c "linenos=table,hl_lines=">}}
+{{< highlight c "linenos=true,hl_lines=">}}
     #define WIFI_SSID CONFIG_ESP_WIFI_SSID
     #define WIFI_PASS CONFIG_ESP_WIFI_PASSWORD
 {{< /highlight >}}


### PR DESCRIPTION
<!--
⚠️ PRE-SUBMISSION REMINDERS
1. Read the project style guidelines (CONTRIBUTING.md).
2. For Work In Progress, please use the Draft PR feature.
3. Ensure you have tested locally with Hugo.
-->

## 📝 Description

<!--
- Summary of the article or changes being introduced.
- Context: Why is this change necessary? (e.g., New tutorial, fixing a typo, updating SDK version).
-->

This PR improves and provides better documentation for code block parameters.

All the parameters were thoroughly tested.

Now, if you scroll long code lines sideways, line numbers (if enabled) also scroll and disappear. Fixing it is not trivial and requires dealing with multiple ramifications. I decided to keep to what we have now. Anyway, the code should not have more than 75 characters per line.

### Adding line numbers

Line numbers can be added in two ways: `inline` and `table`. With out existing CSS styles and some stabs to remove line numbers from the copied code, `inline` works great and was made a default option.

`table` was designed to be static when code is scrolled (it doesn't work), line numbers are placed in a separate table column, good, but our current CSS styles format it in a way that there is no gap between line numbers and code. I switched it off.

If clickable line numbers are available, a prefix should be added to each of such code blocks. Otherwise, the links for the same line number will be identical. 

### Code highlighter

Looks like the code highlighter cannot be changed and the existing one is one of the best highlighters.

## Publish date

Expected publish date: `YYYY-MM-DD`

<!--
Please note the expected review time:
  - Announcements:  within 1 week
  - Simple articles:       1-2 weeks
  - Tutorial or workshops: 3-4 weeks
-->

## Review process

- [ ] Initiate **technical review**
    - [ ] This item is N/A
    - Add subject matter experts (your team members, experts in the field)
- [ ] Once tech review mostly done, initiate **editorial review**
    - Add technical editors (`@f-hollow`, `@FBEZ`, and/or `@pedrominatel`)

## Checks

- [ ] Article folder and file names:
    - Folder path is `content/blog/YYYY/MM/my-new-article` (articles only)
    - Folder and file names have no underscores, spaces, or uppercase letters (~~My new_article~~)
- [ ] New article's YAML frontmatter:
    - Title updated
    - Date matches the format `date: 20YY-MM-DD`
    - Summary updated
    - Authors added (see [Add youself as an author](https://developer.espressif.com/pages/contribution-guide/writing-content/#add-youself-as-an-author))
    - Tags added
- [ ] Updated article's YAML frontmatter:<br>
    - [ ] This item is N/A
    - If article folder is moved or renamed, the field `aliases:` with a new URL slug is added
    - Date of update is added `lastmode: 20YY-MM-DD`
- [ ] Article media files:
    - All images are in .WebP format (see [Use WebP for raster images](https://developer.espressif.com/pages/contribution-guide/writing-content/#use-webp-for-raster-images))
    - Images are compressed within 100-300 KB, with a hard limit of ≤ 500 kB
    - Where possible, Hugo shortcodes are used instead of raw HTML for content types unsupported by markdown (see [Use additional content types](https://developer.espressif.com/pages/contribution-guide/writing-content/#use-additional-content-types))
- [ ] Links in articles
    - Make sure all links are valid
    - No links to Google docs present
    - Use a specific ESP-IDF version in links (avoid `stable`, hard no for `latest`)
- [ ] Git history
    - Commits are clean and squashed to the minimum necessary
    - Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
    - Your feature branch is rebased on `main`

## 🔗 Related

<!--
- Fixes #ISSUENUMBER
- Related #PRNUMBER
- Links to related documentation
-->



## 🧪 Testing (Hugo)

<!--
Describe how you tested or verified your contribution. For example, you can say:

- [ ] I have run `hugo server` locally and verified there are no build errors.
- [ ] I have checked the rendered output on Desktop and Mobile view.
- [ ] I have verified that internal links and syntax highlighting work correctly.
-->
