### PR TITLE
ci: link pr preview comment to changed articles

### DIFF
--- a/.github/workflows/pr-build-preview.yml
+++ b/.github/workflows/pr-build-preview.yml
@@ -35,6 +35,15 @@ jobs:
           printf '%s\n' "$PR_HEAD_REF" > pr_head_ref.txt
           printf '%s\n' "$PR_HEAD_SHA" > pr_head_sha.txt
 
+      - name: Collect articles touched by this PR
+        continue-on-error: true
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          bash tools/ci/collect_pr_articles.sh \
+            "$PR_BASE_SHA" "$PR_HEAD_SHA" pr_articles.txt
+
       - name: Add preview banner to website
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -73,6 +82,7 @@ jobs:
             pr_url.txt
             pr_head_ref.txt
             pr_head_sha.txt
+            pr_articles.txt
           retention-days: 3
 
       - name: Upload built site

--- a/.github/workflows/prw-deploy-preview.yml
+++ b/.github/workflows/prw-deploy-preview.yml
@@ -125,9 +125,31 @@ jobs:
                 repo: context.repo.repo
               });
 
+              const fs = require('fs');
+              const baseUrl = process.env.HUGO_BASEURL;
+
+              // Link straight to the articles this PR touches, so reviewers
+              // land on the changed content instead of the portal home page.
+              let articles = [];
+              try {
+                articles = fs.readFileSync('pr_articles.txt', 'utf8')
+                  .split('\n')
+                  .map(line => line.trim())
+                  .filter(Boolean);
+              } catch (error) {
+                core.info(`No article list available: ${error.message}`);
+              }
+
+              const links = articles.length
+                ? articles.map(path => `- ${baseUrl}${path}`).join('\n')
+                : baseUrl;
+
               // Define the comment body
-              const commentBody = `🎉 A preview for this PR is available at: ${process.env.HUGO_BASEURL}
-              \n\n> [!WARNING]\n>This link is **for review only** and will expire after merge. Don't share it publicly.`;
+              const commentBody =
+                `🎉 A preview for this PR is available at:\n\n${links}\n\n` +
+                `> [!WARNING]\n` +
+                `>This link is **for review only** and will expire after merge. ` +
+                `Don't share it publicly.`;
 
               // Look for an existing comment containing the specific text
               const existingComment = comments.find(comment =>

--- a/tools/ci/collect_pr_articles.sh
+++ b/tools/ci/collect_pr_articles.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Collect the site paths of articles touched by a pull request.
+#
+# Reads the list of files changed between the base and head commits and maps
+# each one to the URL path of the article it belongs to. Blog posts are leaf
+# bundles, so the article root is the directory holding index.md. Workshops are
+# branch bundles with sub-pages, so the article root is the top-level workshop
+# directory.
+#
+# Usage: collect_pr_articles.sh <base-sha> <head-sha> <output-file>
+
+set -euo pipefail
+
+BASE_SHA="${1:?base sha required}"
+HEAD_SHA="${2:?head sha required}"
+OUT_FILE="${3:?output file required}"
+
+: > "$OUT_FILE"
+
+if ! MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null)"; then
+  if git rev-parse --verify --quiet "${BASE_SHA}^{commit}" >/dev/null; then
+    MERGE_BASE="$BASE_SHA"
+  else
+    echo "Base commit $BASE_SHA unavailable; no article list produced."
+    exit 0
+  fi
+fi
+
+git diff --name-only --diff-filter=d "$MERGE_BASE" "$HEAD_SHA" \
+  | while IFS= read -r file; do
+      case "$file" in
+        content/blog/*)
+          # Strip the file name and walk up to the directory holding index.md.
+          dir="${file%/*}"
+          while [ "$dir" != "content/blog" ] && [ "$dir" != "content" ] && [ -n "$dir" ]; do
+            if [ -f "$dir/index.md" ] || [ -f "$dir/_index.md" ]; then
+              printf '%s/\n' "${dir#content/}"
+              break
+            fi
+            dir="${dir%/*}"
+          done
+          ;;
+        content/workshops/*)
+          # Keep only the top-level workshop directory.
+          rest="${file#content/workshops/}"
+          workshop="${rest%%/*}"
+          [ "$workshop" = "$rest" ] && continue
+          printf 'workshops/%s/\n' "$workshop"
+          ;;
+      esac
+    done \
+  | sort -u > "$OUT_FILE"
+
+echo "Articles touched by this PR:"
+cat "$OUT_FILE"


### PR DESCRIPTION
The preview comment pointed at the portal root, so reviewers had to navigate to the article under review themselves. Map each changed file under content/blog and content/workshops to its article URL and list those links instead, falling back to the root link when a PR touches no article.

The mapping never blocks a preview: an unreachable base commit yields an empty list rather than an error, and the step is non-fatal.
